### PR TITLE
Fix wrong icinga web 2 config.ini resource

### DIFF
--- a/charts/icinga-stack/charts/icingaweb2/templates/_icingaweb-config.tpl
+++ b/charts/icinga-stack/charts/icingaweb2/templates/_icingaweb-config.tpl
@@ -22,10 +22,8 @@
   value: {{ .Values.auth.resource | default .Values.global.databases.icingaweb2.database | quote }}
 - name: "icingaweb.passwords.icingaweb2.{{ .Values.auth.admin_user}}"
   value: {{ $auth_admin_password | quote }}
-- name: icingaweb.config.global.config_backend
-  value: {{ .Values.auth.resource | default .Values.global.databases.icingaweb2.database | quote }}
 - name: icingaweb.config.global.config_resource
-  value: {{ .Values.auth.type | quote }}
+  value: {{ .Values.auth.resource | default .Values.global.databases.icingaweb2.database | quote }}
 - name: icingaweb.groups.icingaweb2.backend
   value: {{ .Values.auth.type | quote }}
 - name: icingaweb.groups.icingaweb2.resource

--- a/charts/icinga-stack/charts/icingaweb2/values.yaml
+++ b/charts/icinga-stack/charts/icingaweb2/values.yaml
@@ -32,6 +32,7 @@ ingress:
 
 auth:
   type: db
+  #resource: # Add the name of the db resource used by Icinga Web 2 here
   admin_user: icingaweb
   admin_password:  # Add a password here
 
@@ -74,7 +75,7 @@ modules:
 
   icingadb:
     enabled: true
-  
+
   incubator:
     enabled: true
 
@@ -100,7 +101,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
-    
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: false

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -253,7 +253,7 @@ icinga2:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   nodeSelector: {}
 
   tolerations: []
@@ -305,7 +305,7 @@ icingadb:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   nodeSelector: {}
 
   tolerations: []
@@ -368,9 +368,10 @@ icingaweb2:
 
   auth:
     type: db
+    #resource: # Add the name of the db resource used by Icinga Web 2 here
     admin_user: icingaweb
     admin_password:  # Add a password here
-  
+
   modules:
     audit:
       enabled: false
@@ -430,13 +431,13 @@ icingaweb2:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
-  
+
   nodeSelector: {}
 
   tolerations: []
 
   affinity: {}
-      
+
   serviceAccount:
     # Specifies whether a service account should be created
     create: false
@@ -458,7 +459,7 @@ icingaweb2:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
     # runAsUser: 1000
-  
+
 global:
   api:
     # host:  # only needed if Icinga2 runs out of cluster
@@ -491,7 +492,7 @@ global:
         # subPath: ""
         matchLabels: {}
         matchExpressions: []
-        
+
     icingadb:
       database: icingadb
       username: icingadb


### PR DESCRIPTION
This PR fixes #6.

It changes the resulting content of **/etc/icingaweb2/config.ini** from

```ini
[global]
config_resource = db
config_backend  = icingaweb2db
```

to

```ini
[global]
config_resource = icingaweb2db
```

within the according container.