### PR TITLE
[Docs] Repo name and value missing for helm installation

### DIFF
--- a/charts/icinga-stack/README.md
+++ b/charts/icinga-stack/README.md
@@ -39,6 +39,7 @@ helm install <release-name> \
   --set icingaweb2.auth.admin_password=CHANGE-ME
   --set global.api.users.director.password=CHANGE-ME
   --set global.api.users.director.icingaweb.password=CHANGE-ME
+  --set global.api.users.icingaweb.password=CHANGE-ME
   --set global.databases.director.password=CHANGE-ME
   --set global.databases.icingaweb2.password=CHANGE-ME
   --set global.databases.icingadb.password=CHANGE-ME

--- a/charts/icinga-stack/README.md
+++ b/charts/icinga-stack/README.md
@@ -42,7 +42,7 @@ helm install <release-name> \
   --set global.databases.director.password=CHANGE-ME
   --set global.databases.icingaweb2.password=CHANGE-ME
   --set global.databases.icingadb.password=CHANGE-ME
-icinga-stack
+icinga/icinga-stack
 ```
 
 This example sets all **required** value for the chart to install successfully. For more information on the available configuration options, see the [configuration](docs/configuration.md#configuration) section.


### PR DESCRIPTION
I just discovered that the Helm repo name and a value is missing for the helm installation command. :smiley: 