### PR TITLE
Icinga2 set ICINGA_DISABLE_CONFD env variable

### DIFF
--- a/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
+++ b/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
@@ -30,6 +30,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: ICINGA_DISABLE_CONFD
+              value: {{ .Values.config.disable_confd | int | quote }}
           ports:
             - name: api
               containerPort: {{ .Values.service.port }}
@@ -62,6 +65,8 @@ spec:
               value: {{ .Values.config.node_name | quote }}
             - name: ICINGA_MASTER
               value: "1"
+            - name: ICINGA_DISABLE_CONFD
+              value: {{ .Values.config.disable_confd | int | quote }}
           volumeMounts:
             - name: data
               mountPath: /data

--- a/charts/icinga-stack/charts/icinga2/values.yaml
+++ b/charts/icinga-stack/charts/icinga2/values.yaml
@@ -31,6 +31,7 @@ config:
   node_name: icinga2-master
   zone_name: master
   ticket_salt:  # Add a random (long!) string here
+  disable_confd: true
 
 features:
   # The features are configured as described in the official documentation 

--- a/charts/icinga-stack/docs/configuration.md
+++ b/charts/icinga-stack/docs/configuration.md
@@ -73,6 +73,7 @@ These values are used by the Icinga2 sub-chart. For configuration of Icinga2's d
 | `icinga2.ingress.tls[].secretName` | Secret name of the Icinga2 ingress | `string` | **not set** |
 | `icinga2.config.node_name` | Name of the Icinga2 node | `string` | `icinga2-master` |
 | `icinga2.config.zone_name` | Name of the Icinga2 zone | `string` | `master` |
+| `icinga2.config.disable_confd` | Disables the `include_recursive "conf.d"` directive in icinga2.conf | `boolean` | `true` |
 | `icinga2.config.ticket_salt` | Salt used to generate API tickets for satellites and agents | `string` | **not set** |
 | `icinga2.features.<feature>.enabled` | Whether or not the respective feature should be enabled | `boolean` | **varies** |
 | `icinga2.persistence.enabled` | Whether or not the Icinga2 deployment should use a persistent volume | `boolean` | `false` |

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -32,6 +32,7 @@ icinga2:
     node_name: icinga2-master
     zone_name: master
     ticket_salt:  # Add a random (long!) string here
+    disable_confd: true
 
   features:
     # The features are configured as described in the official documentation 


### PR DESCRIPTION
This PR resolves #5.

It adds new configuration parameter to Icinga 2 chart  which sets ICINGA_DISABLE_CONFD environment variable of Icinga2 docker to enable or disable `include_recursive "conf.d"` directive in icinga2.conf.