### PR TITLE
Adds charts/**/Chart.yaml to paths needed to trigger a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - charts/**/Chart.yaml
 
 jobs:
   release:


### PR DESCRIPTION
Reasoning behind this PR:

Right now we can't accept arbitrary PRs to `main` as this would always trigger the `release` workflow, which in turn would fail unless we bump a chart's version.

Adding a `path`-based trigger changes the `release` workflow in a way that only triggers it when a push to `main` happens which includes changes to `charts/XY/Chart.yaml` going forward. 

This way we can make sure to only trigger releases when we actually want to do so and can accept PRs to `main` without restrictions or failing pipelines again.