### PR TITLE
doc: Remove extraneous secret

### DIFF
--- a/charts/icinga-stack/README.md
+++ b/charts/icinga-stack/README.md
@@ -38,7 +38,6 @@ helm install <release-name> \
   --set icinga2.config.ticket_salt=CHANGE-ME
   --set icingaweb2.auth.admin_password=CHANGE-ME
   --set global.api.users.director.password=CHANGE-ME
-  --set global.api.users.director.icingaweb.password=CHANGE-ME
   --set global.api.users.icingaweb.password=CHANGE-ME
   --set global.databases.director.password=CHANGE-ME
   --set global.databases.icingaweb2.password=CHANGE-ME


### PR DESCRIPTION
The documentation shows 8 different secrets that can be configured  Config `global.api.users.director.icingaweb.password` doesn't exist in the default `values.yaml` for the Chart, nor does it appear in `docs/configuration.md#configuration`.  It may be a typo or bad copy-pasta, so I've suggested removal it to reduce confusion.

- exists: `global.api.users.director.password`
- exists: `global.api.users.icingaweb.password`
- non-existent: `global.api.users.director.icingaweb.password`