### PR TITLE
use secrets for certificates

### DIFF
--- a/charts/icinga-stack/charts/icinga2/templates/_env_secrets.tpl
+++ b/charts/icinga-stack/charts/icinga2/templates/_env_secrets.tpl
@@ -25,7 +25,7 @@
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if and .Values.features.elasticsearch.enabled (or (.Values.features.elasticsearch.username.value) (and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.username.secretKey)) }}
+{{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.username (or (.Values.features.elasticsearch.username.value) (and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.username.secretKey)) }}
 - name: ICINGA_ELASTICSEARCH_USERNAME
   {{- if .Values.features.elasticsearch.username.value }}
   value: {{ .Values.features.elasticsearch.username.value | quote }}
@@ -36,7 +36,7 @@
       key: {{ .Values.features.elasticsearch.username.secretKey  | quote }}
   {{- end }}
 {{- end }}
-{{- if and .Values.features.elasticsearch.enabled (or (.Values.features.elasticsearch.password.value) (and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.password.secretKey)) }}
+{{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.password (or (.Values.features.elasticsearch.password.value) (and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.password.secretKey)) }}
 - name: ICINGA_ELASTICSEARCH_PASSWORD
   {{- if .Values.features.elasticsearch.password.value }}
   value: {{ .Values.features.elasticsearch.password.value | quote }}
@@ -47,17 +47,30 @@
       key: {{ .Values.features.elasticsearch.password.secretKey  | quote }}
   {{- end }}
 {{- end }}
+{{- if and .Values.features.icingadb.enabled .Values.features.icingadb.password }}
+- name: ICINGA_ICINGADB_PASSWORD
+{{- if .Values.features.icingadb.password.value }}
+  value: {{ .Values.features.icingadb.password.value | quote }}
+{{- else if and .Values.features.icingadb.secretName .Values.features.icingadb.password.secretKey }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.features.icingadb.secretName | quote }}
+      key: {{ .Values.features.icingadb.password.secretKey  | quote }}
+{{- else }}
+  {{ fail "icingadb password partially set. Set either .Values.features.icingadb.password.value or .Values.features.icingadb.secretName and .Values.features.icingadb.password.secretKey" }}
+{{- end }}
+{{- end }}
 {{- if .Values.features.influxdb2.enabled }}
 - name: ICINGA_INFLUXDB2_AUTH_TOKEN
   {{- if and .Values.features.influxdb2.auth_token .Values.features.influxdb2.auth_token.value }}
   value: {{ .Values.features.influxdb2.auth_token.value | quote }}
-  {{- else if and .Values.features.influxdb2.auth_token .Values.features.influxdb2.auth_token.secretName .Values.features.influxdb2.auth_token.secretKey }}
+  {{- else if and .Values.features.influxdb2.auth_token .Values.features.influxdb2.secretName .Values.features.influxdb2.auth_token.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.features.influxdb2.auth_token.secretName | quote }}
+      name: {{ .Values.features.influxdb2.secretName | quote }}
       key: {{ .Values.features.influxdb2.auth_token.secretKey  | quote }}
   {{- else }}
-    {{ fail "Icinga InfluxDB2 auth_token not set. Either set .Values.features.influxdb2.auth_token.value or .Values.features.influxdb2.auth_token.secretName and .Values.features.influxdb2.auth_token.secretKey" }}
+    {{ fail "Icinga InfluxDB2 auth_token not set. Either set .Values.features.influxdb2.auth_token.value or .Values.features.influxdb2.secretName and .Values.features.influxdb2.auth_token.secretKey" }}
   {{- end }}
 {{- end }}
 {{- if .Values.features.influxdb.enabled }}

--- a/charts/icinga-stack/charts/icinga2/templates/_env_secrets.tpl
+++ b/charts/icinga-stack/charts/icinga2/templates/_env_secrets.tpl
@@ -2,48 +2,48 @@
 - name: ICINGA_TICKET_SALT
   {{- if .Values.config.ticket_salt.value  }}
   value: {{ .Values.config.ticket_salt.value | quote }}
-  {{- else if and (.Values.config.ticket_salt.secretName) (.Values.config.ticket_salt.secretKey) }}
+  {{- else if and (.Values.config.ticket_salt.credSecret) (.Values.config.ticket_salt.secretKey) }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.config.ticket_salt.secretName | quote }}
+      name: {{ .Values.config.ticket_salt.credSecret | quote }}
       key: {{ .Values.config.ticket_salt.secretKey | quote }}
   {{- else }}
-    {{ fail "Icinga TicketSalt not set. Either set .Values.config.ticket_salt.value or .Values.config.ticket_salt.secretName and .Values.config.ticket_salt.secretKey" }}
+    {{ fail "Icinga TicketSalt not set. Either set .Values.config.ticket_salt.value or .Values.config.ticket_salt.credSecret and .Values.config.ticket_salt.secretKey" }}
   {{- end }}
 {{- range $user, $settings := .Values.global.api.users }}
-{{- if ne $user "secretName" }} # skip secretName key
+{{- if ne $user "credSecret" }} # skip credSecret key
 - name: {{ print "ICINGA_" $user "_API_PASSWORD" | upper }}
 {{- if and $settings.password $settings.password.value }}
   value: {{ $settings.password.value | quote }}
-{{- else if and $.Values.global.api.users.secretName $settings.password $settings.password.secretKey }}
+{{- else if and $.Values.global.api.users.credSecret $settings.password $settings.password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ $.Values.global.api.users.secretName | quote }}
+      name: {{ $.Values.global.api.users.credSecret | quote }}
       key: {{ $settings.password.secretKey | quote }}
 {{- else }}
-{{ fail (print $user " api user password not set. Set either .Values.global.api.users." $user ".password.value or .Values.global.api.users.secretName and .Values.global.api.users." $user ".password.secretKey") }}
+{{ fail (print $user " api user password not set. Set either .Values.global.api.users." $user ".password.value or .Values.global.api.users.credSecret and .Values.global.api.users." $user ".password.secretKey") }}
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.username (or (.Values.features.elasticsearch.username.value) (and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.username.secretKey)) }}
+{{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.username (or (.Values.features.elasticsearch.username.value) (and .Values.features.elasticsearch.credSecret .Values.features.elasticsearch.username.secretKey)) }}
 - name: ICINGA_ELASTICSEARCH_USERNAME
   {{- if .Values.features.elasticsearch.username.value }}
   value: {{ .Values.features.elasticsearch.username.value | quote }}
-  {{- else if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.username.secretKey }}
+  {{- else if and .Values.features.elasticsearch.credSecret .Values.features.elasticsearch.username.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.features.elasticsearch.secretName | quote }}
+      name: {{ .Values.features.elasticsearch.credSecret | quote }}
       key: {{ .Values.features.elasticsearch.username.secretKey  | quote }}
   {{- end }}
 {{- end }}
-{{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.password (or (.Values.features.elasticsearch.password.value) (and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.password.secretKey)) }}
+{{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.password (or (.Values.features.elasticsearch.password.value) (and .Values.features.elasticsearch.credSecret .Values.features.elasticsearch.password.secretKey)) }}
 - name: ICINGA_ELASTICSEARCH_PASSWORD
   {{- if .Values.features.elasticsearch.password.value }}
   value: {{ .Values.features.elasticsearch.password.value | quote }}
-  {{- else if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.password.secretKey }}
+  {{- else if and .Values.features.elasticsearch.credSecret .Values.features.elasticsearch.password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.features.elasticsearch.secretName | quote }}
+      name: {{ .Values.features.elasticsearch.credSecret | quote }}
       key: {{ .Values.features.elasticsearch.password.secretKey  | quote }}
   {{- end }}
 {{- end }}
@@ -51,26 +51,26 @@
 - name: ICINGA_ICINGADB_PASSWORD
 {{- if .Values.features.icingadb.password.value }}
   value: {{ .Values.features.icingadb.password.value | quote }}
-{{- else if and .Values.features.icingadb.secretName .Values.features.icingadb.password.secretKey }}
+{{- else if and .Values.features.icingadb.credSecret .Values.features.icingadb.password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.features.icingadb.secretName | quote }}
+      name: {{ .Values.features.icingadb.credSecret | quote }}
       key: {{ .Values.features.icingadb.password.secretKey  | quote }}
 {{- else }}
-  {{ fail "icingadb password partially set. Set either .Values.features.icingadb.password.value or .Values.features.icingadb.secretName and .Values.features.icingadb.password.secretKey" }}
+  {{ fail "icingadb password partially set. Set either .Values.features.icingadb.password.value or .Values.features.icingadb.credSecret and .Values.features.icingadb.password.secretKey" }}
 {{- end }}
 {{- end }}
 {{- if .Values.features.influxdb2.enabled }}
 - name: ICINGA_INFLUXDB2_AUTH_TOKEN
   {{- if and .Values.features.influxdb2.auth_token .Values.features.influxdb2.auth_token.value }}
   value: {{ .Values.features.influxdb2.auth_token.value | quote }}
-  {{- else if and .Values.features.influxdb2.auth_token .Values.features.influxdb2.secretName .Values.features.influxdb2.auth_token.secretKey }}
+  {{- else if and .Values.features.influxdb2.auth_token .Values.features.influxdb2.credSecret .Values.features.influxdb2.auth_token.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.features.influxdb2.secretName | quote }}
+      name: {{ .Values.features.influxdb2.credSecret | quote }}
       key: {{ .Values.features.influxdb2.auth_token.secretKey  | quote }}
   {{- else }}
-    {{ fail "Icinga InfluxDB2 auth_token not set. Either set .Values.features.influxdb2.auth_token.value or .Values.features.influxdb2.secretName and .Values.features.influxdb2.auth_token.secretKey" }}
+    {{ fail "Icinga InfluxDB2 auth_token not set. Either set .Values.features.influxdb2.auth_token.value or .Values.features.influxdb2.credSecret and .Values.features.influxdb2.auth_token.secretKey" }}
   {{- end }}
 {{- end }}
 {{- if .Values.features.influxdb.enabled }}
@@ -78,19 +78,19 @@
 - name: ICINGA_INFLUXDB_USERNAME
 {{- if .Values.features.influxdb.username.value }}
   value: {{ .Values.features.influxdb.username.value | quote }}
-{{- else if and .Values.features.influxdb.secretName .Values.features.influxdb.username.secretKey }}
+{{- else if and .Values.features.influxdb.credSecret .Values.features.influxdb.username.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.features.influxdb.secretName | quote }}
+      name: {{ .Values.features.influxdb.credSecret | quote }}
       key: {{ .Values.features.influxdb.username.secretKey  | quote }}
 {{- end}}
 - name: ICINGA_INFLUXDB_PASSWORD
 {{- if .Values.features.influxdb.password.value }}
   value: {{ .Values.features.influxdb.password.value | quote }}
-{{- else if and .Values.features.influxdb.secretName .Values.features.influxdb.password.secretKey }}
+{{- else if and .Values.features.influxdb.credSecret .Values.features.influxdb.password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.features.influxdb.secretName | quote }}
+      name: {{ .Values.features.influxdb.credSecret | quote }}
       key: {{ .Values.features.influxdb.password.secretKey  | quote }}
 {{- end }}
 {{- end }}
@@ -99,19 +99,19 @@
 - name: ICINGA_INFLUXDB_BASIC_AUTH_USERNAME
 {{- if .Values.features.influxdb.basic_auth.username.value }}
   value: {{ .Values.features.influxdb.basic_auth.username.value | quote }}
-{{- else if and .Values.features.influxdb.secretName .Values.features.influxdb.basic_auth.username.secretKey }}
+{{- else if and .Values.features.influxdb.credSecret .Values.features.influxdb.basic_auth.username.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.features.influxdb.secretName | quote }}
+      name: {{ .Values.features.influxdb.credSecret | quote }}
       key: {{ .Values.features.influxdb.basic_auth.username.secretKey  | quote }}
 {{- end}}
 - name: ICINGA_INFLUXDB_BASIC_AUTH_PASSWORD
 {{- if .Values.features.influxdb.basic_auth.password.value }}
   value: {{ .Values.features.influxdb.basic_auth.password.value | quote }}
-{{- else if and .Values.features.influxdb.secretName .Values.features.influxdb.basic_auth.password.secretKey }}
+{{- else if and .Values.features.influxdb.credSecret .Values.features.influxdb.basic_auth.password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.features.influxdb.secretName | quote }}
+      name: {{ .Values.features.influxdb.credSecret | quote }}
       key: {{ .Values.features.influxdb.basic_auth.password.secretKey  | quote }}
 {{- end }}
 {{- end }}

--- a/charts/icinga-stack/charts/icinga2/templates/_secret_mounts.tpl
+++ b/charts/icinga-stack/charts/icinga2/templates/_secret_mounts.tpl
@@ -1,0 +1,47 @@
+{{- define "icinga2.secretMounts" -}}
+{{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.enable_tls }}
+{{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.caSecretKey .Values.features.elasticsearch.certSecretKey .Values.features.elasticsearch.keySecretKey }}
+- name: elastic-certs
+  mountPath: "/etc/icinga2-pki/elastic"
+  readOnly: true
+{{- else }}
+  {{ fail "Elasticsearch certs not set. Set .Values.features.elasticsearch.secretName, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey" }}
+{{- end }}
+{{- end }}
+{{- if and .Values.features.gelf.enabled .Values.features.gelf.enable_tls }}
+{{- if and .Values.features.gelf.secretName .Values.features.gelf.caSecretKey .Values.features.gelf.certSecretKey .Values.features.gelf.keySecretKey }}
+- name: gelf-certs
+  mountPath: "/etc/icinga2-pki/gelf"
+  readOnly: true
+{{- else }}
+  {{ fail "GELF certs not set. Set .Values.features.gelf.secretName, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey" }}
+{{- end }}
+{{- end }}
+{{- if and .Values.features.icingadb.enabled .Values.features.icingadb.enable_tls }}
+{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.caSecretKey .Values.features.icingadb.certSecretKey .Values.features.icingadb.keySecretKey .Values.features.icingadb.crlSecretKey }}
+- name: icingadb-certs
+  mountPath: "/etc/icinga2-pki/icingadb"
+  readOnly: true
+{{- else }}
+  {{ fail "icingadb cert secrets not set. Set .Values.features.icingadb.secretName, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey" }}
+{{- end }}
+{{- end }}
+{{- if and .Values.features.influxdb2.enabled .Values.features.influxdb2.ssl_enable }}
+{{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.caSecretKey .Values.features.influxdb2.certSecretKey .Values.features.influxdb2.keySecretKey }}
+- name: influxdb2-certs
+  mountPath: "/etc/icinga2-pki/influxdb2"
+  readOnly: true
+{{- else }}
+  {{ fail "influxdb2 cert secrets not set. Set .Values.features.influxdb2.secretName, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey" }}
+{{- end }}
+{{- end }}
+{{- if and .Values.features.influxdb.enabled .Values.features.influxdb.ssl_enable }}
+{{- if and .Values.features.influxdb.secretName .Values.features.influxdb.caSecretKey .Values.features.influxdb.certSecretKey .Values.features.influxdb.keySecretKey }}
+- name: influxdb-certs
+  mountPath: "/etc/icinga2-pki/influxdb"
+  readOnly: true
+{{- else }}
+  {{ fail "influxdb cert secrets not set. Set .Values.features.influxdb.secretName, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey" }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/icinga-stack/charts/icinga2/templates/_secret_mounts.tpl
+++ b/charts/icinga-stack/charts/icinga2/templates/_secret_mounts.tpl
@@ -1,47 +1,47 @@
 {{- define "icinga2.secretMounts" -}}
 {{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.enable_tls }}
-{{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.caSecretKey .Values.features.elasticsearch.certSecretKey .Values.features.elasticsearch.keySecretKey }}
+{{- if and .Values.features.elasticsearch.tlsSecret .Values.features.elasticsearch.caSecretKey .Values.features.elasticsearch.certSecretKey .Values.features.elasticsearch.keySecretKey }}
 - name: elastic-certs
   mountPath: "/etc/icinga2-pki/elastic"
   readOnly: true
 {{- else }}
-  {{ fail "Elasticsearch certs not set. Set .Values.features.elasticsearch.secretName, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey" }}
+  {{ fail "Elasticsearch certs not set. Set .Values.features.elasticsearch.tlsSecret, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey" }}
 {{- end }}
 {{- end }}
 {{- if and .Values.features.gelf.enabled .Values.features.gelf.enable_tls }}
-{{- if and .Values.features.gelf.secretName .Values.features.gelf.caSecretKey .Values.features.gelf.certSecretKey .Values.features.gelf.keySecretKey }}
+{{- if and .Values.features.gelf.tlsSecret .Values.features.gelf.caSecretKey .Values.features.gelf.certSecretKey .Values.features.gelf.keySecretKey }}
 - name: gelf-certs
   mountPath: "/etc/icinga2-pki/gelf"
   readOnly: true
 {{- else }}
-  {{ fail "GELF certs not set. Set .Values.features.gelf.secretName, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey" }}
+  {{ fail "GELF certs not set. Set .Values.features.gelf.tlsSecret, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey" }}
 {{- end }}
 {{- end }}
 {{- if and .Values.features.icingadb.enabled .Values.features.icingadb.enable_tls }}
-{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.caSecretKey .Values.features.icingadb.certSecretKey .Values.features.icingadb.keySecretKey .Values.features.icingadb.crlSecretKey }}
+{{- if and .Values.features.icingadb.tlsSecret .Values.features.icingadb.caSecretKey .Values.features.icingadb.certSecretKey .Values.features.icingadb.keySecretKey .Values.features.icingadb.crlSecretKey }}
 - name: icingadb-certs
   mountPath: "/etc/icinga2-pki/icingadb"
   readOnly: true
 {{- else }}
-  {{ fail "icingadb cert secrets not set. Set .Values.features.icingadb.secretName, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey" }}
+  {{ fail "icingadb cert secrets not set. Set .Values.features.icingadb.tlsSecret, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey" }}
 {{- end }}
 {{- end }}
 {{- if and .Values.features.influxdb2.enabled .Values.features.influxdb2.ssl_enable }}
-{{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.caSecretKey .Values.features.influxdb2.certSecretKey .Values.features.influxdb2.keySecretKey }}
+{{- if and .Values.features.influxdb2.tlsSecret .Values.features.influxdb2.caSecretKey .Values.features.influxdb2.certSecretKey .Values.features.influxdb2.keySecretKey }}
 - name: influxdb2-certs
   mountPath: "/etc/icinga2-pki/influxdb2"
   readOnly: true
 {{- else }}
-  {{ fail "influxdb2 cert secrets not set. Set .Values.features.influxdb2.secretName, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey" }}
+  {{ fail "influxdb2 cert secrets not set. Set .Values.features.influxdb2.tlsSecret, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey" }}
 {{- end }}
 {{- end }}
 {{- if and .Values.features.influxdb.enabled .Values.features.influxdb.ssl_enable }}
-{{- if and .Values.features.influxdb.secretName .Values.features.influxdb.caSecretKey .Values.features.influxdb.certSecretKey .Values.features.influxdb.keySecretKey }}
+{{- if and .Values.features.influxdb.tlsSecret .Values.features.influxdb.caSecretKey .Values.features.influxdb.certSecretKey .Values.features.influxdb.keySecretKey }}
 - name: influxdb-certs
   mountPath: "/etc/icinga2-pki/influxdb"
   readOnly: true
 {{- else }}
-  {{ fail "influxdb cert secrets not set. Set .Values.features.influxdb.secretName, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey" }}
+  {{ fail "influxdb cert secrets not set. Set .Values.features.influxdb.tlsSecret, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey" }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/icinga-stack/charts/icinga2/templates/_secret_volumes.tpl
+++ b/charts/icinga-stack/charts/icinga2/templates/_secret_volumes.tpl
@@ -1,0 +1,148 @@
+{{- define "icinga2.secretVolumes" -}}
+{{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.enable_tls }}
+{{- if .Values.features.elasticsearch.secretName }}
+- name: elastic-certs
+  secret:
+    secretName: {{ .Values.features.elasticsearch.secretName | quote }}
+    items:
+{{- else }}
+  {{ fail "Elasticsearch secret not set. Set .Values.features.elasticsearch.secretName" }}
+{{- end }}
+{{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.caSecretKey }}
+    - key: {{ .Values.features.elasticsearch.caSecretKey | quote }}
+      path: "ca.crt"
+{{- else }}
+  {{ fail "Elasticsearch CA cert not set. Set both .Values.features.elasticsearch.secretName and .Values.features.elasticsearch.caSecretKey" }}
+{{- end }}
+{{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.certSecretKey }}
+    - key: {{ .Values.features.elasticsearch.certSecretKey | quote }}
+      path: "cert.crt"
+{{- else }}
+  {{ fail "Elasticsearch cert not set. Set both .Values.features.elasticsearch.secretName and .Values.features.elasticsearch.certSecretKey" }}
+{{- end }}
+{{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.keySecretKey }}
+    - key: {{ .Values.features.elasticsearch.keySecretKey | quote }}
+      path: "cert.key"
+{{- else }}
+  {{ fail "Elasticsearch cert key not set. Set both .Values.features.elasticsearch.secretName and .Values.features.elasticsearch.keySecretKey" }}
+{{- end }}
+{{- end }}
+{{- if and .Values.features.gelf.enabled .Values.features.gelf.enable_tls }}
+{{- if .Values.features.gelf.secretName }}
+- name: gelf-certs
+  secret:
+    secretName: {{ .Values.features.gelf.secretName | quote }}
+    items:
+{{- else }}
+  {{ fail "gelf secret not set. Set .Values.features.gelf.secretName" }}
+{{- end }}
+{{- if and .Values.features.gelf.secretName .Values.features.gelf.caSecretKey }}
+    - key: {{ .Values.features.gelf.caSecretKey | quote }}
+      path: "ca.crt"
+{{- else }}
+  {{ fail "gelf CA cert not set. Set both .Values.features.gelf.secretName and .Values.features.gelf.caSecretKey" }}
+{{- end }}
+{{- if and .Values.features.gelf.secretName .Values.features.gelf.certSecretKey }}
+    - key: {{ .Values.features.gelf.certSecretKey | quote }}
+      path: "cert.crt"
+{{- else }}
+  {{ fail "gelf cert not set. Set both .Values.features.gelf.secretName and .Values.features.gelf.certSecretKey" }}
+{{- end }}
+{{- if and .Values.features.gelf.secretName .Values.features.gelf.keySecretKey }}
+    - key: {{ .Values.features.gelf.keySecretKey | quote }}
+      path: "cert.key"
+{{- else }}
+  {{ fail "gelf cert key not set. Set both .Values.features.gelf.secretName and .Values.features.gelf.keySecretKey" }}
+{{- end }}
+{{- end }}
+{{- if and .Values.features.icingadb.enabled .Values.features.icingadb.enable_tls }}
+{{- if and .Values.features.icingadb.secretName }}
+- name: icingadb-certs
+  secret:
+    secretName: {{ .Values.features.icingadb.secretName | quote }}
+    items:
+{{- else }}
+  {{ fail "icingadb secret not set. Set .Values.features.icingadb.secretName" }}
+{{- end }}
+{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.caSecretKey }}
+    - key: {{ .Values.features.icingadb.caSecretKey | quote }}
+      path: "ca.crt"
+{{- else }}
+  {{ fail "icingadb CA cert not set. Set both .Values.features.icingadb.secretName and .Values.features.icingadb.caSecretKey" }}
+{{- end }}
+{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.certSecretKey }}
+    - key: {{ .Values.features.icingadb.certSecretKey | quote }}
+      path: "cert.crt"
+{{- else }}
+  {{ fail "icingadb cert not set. Set both .Values.features.icingadb.secretName and .Values.features.icingadb.certSecretKey" }}
+{{- end }}
+{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.keySecretKey }}
+    - key: {{ .Values.features.icingadb.keySecretKey | quote }}
+      path: "cert.key"
+{{- else }}
+  {{ fail "icingadb cert key not set. Set both .Values.features.icingadb.secretName and .Values.features.icingadb.keySecretKey" }}
+{{- end }}
+{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.crlSecretKey }}
+    - key: {{ .Values.features.icingadb.crlSecretKey | quote }}
+      path: "crl.pem"
+{{- else }}
+  {{ fail "icingadb cert key not set. Set both .Values.features.icingadb.secretName and .Values.features.icingadb.crlSecretKey" }}
+{{- end }}
+{{- end }}
+{{- if and .Values.features.influxdb2.enabled .Values.features.influxdb2.ssl_enable }}
+{{- if and .Values.features.influxdb2.secretName }}
+- name: influxdb2-certs
+  secret:
+    secretName: {{ .Values.features.influxdb2.secretName | quote }}
+    items:
+{{- else }}
+  {{ fail "influxdb2 secret not set. Set .Values.features.influxdb2.secretName" }}
+{{- end }}
+{{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.caSecretKey }}
+    - key: {{ .Values.features.influxdb2.caSecretKey | quote }}
+      path: "ca.crt"
+{{- else }}
+  {{ fail "influxdb2 CA cert not set. Set both .Values.features.influxdb2.secretName and .Values.features.influxdb2.caSecretKey" }}
+{{- end }}
+{{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.certSecretKey }}
+    - key: {{ .Values.features.influxdb2.certSecretKey | quote }}
+      path: "cert.crt"
+{{- else }}
+  {{ fail "influxdb2 cert not set. Set both .Values.features.influxdb2.secretName and .Values.features.influxdb2.certSecretKey" }}
+{{- end }}
+{{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.keySecretKey }}
+    - key: {{ .Values.features.influxdb2.keySecretKey | quote }}
+      path: "cert.key"
+{{- else }}
+  {{ fail "influxdb2 cert key not set. Set both .Values.features.influxdb2.secretName and .Values.features.influxdb2.keySecretKey" }}
+{{- end }}
+{{- end }}
+{{- if and .Values.features.influxdb.enabled .Values.features.influxdb.ssl_enable }}
+{{- if and .Values.features.influxdb.secretName }}
+- name: influxdb-certs
+  secret:
+    secretName: {{ .Values.features.influxdb.secretName | quote }}
+    items:
+{{- else }}
+  {{ fail "influxdb secret not set. Set .Values.features.influxdb.secretName" }}
+{{- end }}
+{{- if and .Values.features.influxdb.secretName .Values.features.influxdb.caSecretKey }}
+    - key: {{ .Values.features.influxdb.caSecretKey | quote }}
+      path: "ca.crt"
+{{- else }}
+  {{ fail "influxdb CA cert not set. Set both .Values.features.influxdb.secretName and .Values.features.influxdb.caSecretKey" }}
+{{- end }}
+{{- if and .Values.features.influxdb.secretName .Values.features.influxdb.certSecretKey }}
+    - key: {{ .Values.features.influxdb.certSecretKey | quote }}
+      path: "cert.crt"
+{{- else }}
+  {{ fail "influxdb cert not set. Set both .Values.features.influxdb.secretName and .Values.features.influxdb.certSecretKey" }}
+{{- end }}
+{{- if and .Values.features.influxdb.secretName .Values.features.influxdb.keySecretKey }}
+    - key: {{ .Values.features.influxdb.keySecretKey | quote }}
+      path: "cert.key"
+{{- else }}
+  {{ fail "influxdb cert key not set. Set both .Values.features.influxdb.secretName and .Values.features.influxdb.keySecretKey" }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/icinga-stack/charts/icinga2/templates/_secret_volumes.tpl
+++ b/charts/icinga-stack/charts/icinga2/templates/_secret_volumes.tpl
@@ -1,148 +1,148 @@
 {{- define "icinga2.secretVolumes" -}}
 {{- if and .Values.features.elasticsearch.enabled .Values.features.elasticsearch.enable_tls }}
-{{- if .Values.features.elasticsearch.secretName }}
+{{- if .Values.features.elasticsearch.tlsSecret }}
 - name: elastic-certs
   secret:
-    secretName: {{ .Values.features.elasticsearch.secretName | quote }}
+    secretName: {{ .Values.features.elasticsearch.tlsSecret | quote }}
     items:
 {{- else }}
-  {{ fail "Elasticsearch secret not set. Set .Values.features.elasticsearch.secretName" }}
+  {{ fail "Elasticsearch secret not set. Set .Values.features.elasticsearch.tlsSecret" }}
 {{- end }}
-{{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.caSecretKey }}
+{{- if and .Values.features.elasticsearch.tlsSecret .Values.features.elasticsearch.caSecretKey }}
     - key: {{ .Values.features.elasticsearch.caSecretKey | quote }}
       path: "ca.crt"
 {{- else }}
-  {{ fail "Elasticsearch CA cert not set. Set both .Values.features.elasticsearch.secretName and .Values.features.elasticsearch.caSecretKey" }}
+  {{ fail "Elasticsearch CA cert not set. Set both .Values.features.elasticsearch.tlsSecret and .Values.features.elasticsearch.caSecretKey" }}
 {{- end }}
-{{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.certSecretKey }}
+{{- if and .Values.features.elasticsearch.tlsSecret .Values.features.elasticsearch.certSecretKey }}
     - key: {{ .Values.features.elasticsearch.certSecretKey | quote }}
       path: "cert.crt"
 {{- else }}
-  {{ fail "Elasticsearch cert not set. Set both .Values.features.elasticsearch.secretName and .Values.features.elasticsearch.certSecretKey" }}
+  {{ fail "Elasticsearch cert not set. Set both .Values.features.elasticsearch.tlsSecret and .Values.features.elasticsearch.certSecretKey" }}
 {{- end }}
-{{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.keySecretKey }}
+{{- if and .Values.features.elasticsearch.tlsSecret .Values.features.elasticsearch.keySecretKey }}
     - key: {{ .Values.features.elasticsearch.keySecretKey | quote }}
       path: "cert.key"
 {{- else }}
-  {{ fail "Elasticsearch cert key not set. Set both .Values.features.elasticsearch.secretName and .Values.features.elasticsearch.keySecretKey" }}
+  {{ fail "Elasticsearch cert key not set. Set both .Values.features.elasticsearch.tlsSecret and .Values.features.elasticsearch.keySecretKey" }}
 {{- end }}
 {{- end }}
 {{- if and .Values.features.gelf.enabled .Values.features.gelf.enable_tls }}
-{{- if .Values.features.gelf.secretName }}
+{{- if .Values.features.gelf.tlsSecret }}
 - name: gelf-certs
   secret:
-    secretName: {{ .Values.features.gelf.secretName | quote }}
+    secretName: {{ .Values.features.gelf.tlsSecret | quote }}
     items:
 {{- else }}
-  {{ fail "gelf secret not set. Set .Values.features.gelf.secretName" }}
+  {{ fail "gelf secret not set. Set .Values.features.gelf.tlsSecret" }}
 {{- end }}
-{{- if and .Values.features.gelf.secretName .Values.features.gelf.caSecretKey }}
+{{- if and .Values.features.gelf.tlsSecret .Values.features.gelf.caSecretKey }}
     - key: {{ .Values.features.gelf.caSecretKey | quote }}
       path: "ca.crt"
 {{- else }}
-  {{ fail "gelf CA cert not set. Set both .Values.features.gelf.secretName and .Values.features.gelf.caSecretKey" }}
+  {{ fail "gelf CA cert not set. Set both .Values.features.gelf.tlsSecret and .Values.features.gelf.caSecretKey" }}
 {{- end }}
-{{- if and .Values.features.gelf.secretName .Values.features.gelf.certSecretKey }}
+{{- if and .Values.features.gelf.tlsSecret .Values.features.gelf.certSecretKey }}
     - key: {{ .Values.features.gelf.certSecretKey | quote }}
       path: "cert.crt"
 {{- else }}
-  {{ fail "gelf cert not set. Set both .Values.features.gelf.secretName and .Values.features.gelf.certSecretKey" }}
+  {{ fail "gelf cert not set. Set both .Values.features.gelf.tlsSecret and .Values.features.gelf.certSecretKey" }}
 {{- end }}
-{{- if and .Values.features.gelf.secretName .Values.features.gelf.keySecretKey }}
+{{- if and .Values.features.gelf.tlsSecret .Values.features.gelf.keySecretKey }}
     - key: {{ .Values.features.gelf.keySecretKey | quote }}
       path: "cert.key"
 {{- else }}
-  {{ fail "gelf cert key not set. Set both .Values.features.gelf.secretName and .Values.features.gelf.keySecretKey" }}
+  {{ fail "gelf cert key not set. Set both .Values.features.gelf.tlsSecret and .Values.features.gelf.keySecretKey" }}
 {{- end }}
 {{- end }}
 {{- if and .Values.features.icingadb.enabled .Values.features.icingadb.enable_tls }}
-{{- if and .Values.features.icingadb.secretName }}
+{{- if and .Values.features.icingadb.tlsSecret }}
 - name: icingadb-certs
   secret:
-    secretName: {{ .Values.features.icingadb.secretName | quote }}
+    secretName: {{ .Values.features.icingadb.tlsSecret | quote }}
     items:
 {{- else }}
-  {{ fail "icingadb secret not set. Set .Values.features.icingadb.secretName" }}
+  {{ fail "icingadb secret not set. Set .Values.features.icingadb.tlsSecret" }}
 {{- end }}
-{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.caSecretKey }}
+{{- if and .Values.features.icingadb.tlsSecret .Values.features.icingadb.caSecretKey }}
     - key: {{ .Values.features.icingadb.caSecretKey | quote }}
       path: "ca.crt"
 {{- else }}
-  {{ fail "icingadb CA cert not set. Set both .Values.features.icingadb.secretName and .Values.features.icingadb.caSecretKey" }}
+  {{ fail "icingadb CA cert not set. Set both .Values.features.icingadb.tlsSecret and .Values.features.icingadb.caSecretKey" }}
 {{- end }}
-{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.certSecretKey }}
+{{- if and .Values.features.icingadb.tlsSecret .Values.features.icingadb.certSecretKey }}
     - key: {{ .Values.features.icingadb.certSecretKey | quote }}
       path: "cert.crt"
 {{- else }}
-  {{ fail "icingadb cert not set. Set both .Values.features.icingadb.secretName and .Values.features.icingadb.certSecretKey" }}
+  {{ fail "icingadb cert not set. Set both .Values.features.icingadb.tlsSecret and .Values.features.icingadb.certSecretKey" }}
 {{- end }}
-{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.keySecretKey }}
+{{- if and .Values.features.icingadb.tlsSecret .Values.features.icingadb.keySecretKey }}
     - key: {{ .Values.features.icingadb.keySecretKey | quote }}
       path: "cert.key"
 {{- else }}
-  {{ fail "icingadb cert key not set. Set both .Values.features.icingadb.secretName and .Values.features.icingadb.keySecretKey" }}
+  {{ fail "icingadb cert key not set. Set both .Values.features.icingadb.tlsSecret and .Values.features.icingadb.keySecretKey" }}
 {{- end }}
-{{- if and .Values.features.icingadb.secretName .Values.features.icingadb.crlSecretKey }}
+{{- if and .Values.features.icingadb.tlsSecret .Values.features.icingadb.crlSecretKey }}
     - key: {{ .Values.features.icingadb.crlSecretKey | quote }}
       path: "crl.pem"
 {{- else }}
-  {{ fail "icingadb cert key not set. Set both .Values.features.icingadb.secretName and .Values.features.icingadb.crlSecretKey" }}
+  {{ fail "icingadb cert key not set. Set both .Values.features.icingadb.tlsSecret and .Values.features.icingadb.crlSecretKey" }}
 {{- end }}
 {{- end }}
 {{- if and .Values.features.influxdb2.enabled .Values.features.influxdb2.ssl_enable }}
-{{- if and .Values.features.influxdb2.secretName }}
+{{- if and .Values.features.influxdb2.tlsSecret }}
 - name: influxdb2-certs
   secret:
-    secretName: {{ .Values.features.influxdb2.secretName | quote }}
+    secretName: {{ .Values.features.influxdb2.tlsSecret | quote }}
     items:
 {{- else }}
-  {{ fail "influxdb2 secret not set. Set .Values.features.influxdb2.secretName" }}
+  {{ fail "influxdb2 secret not set. Set .Values.features.influxdb2.tlsSecret" }}
 {{- end }}
-{{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.caSecretKey }}
+{{- if and .Values.features.influxdb2.tlsSecret .Values.features.influxdb2.caSecretKey }}
     - key: {{ .Values.features.influxdb2.caSecretKey | quote }}
       path: "ca.crt"
 {{- else }}
-  {{ fail "influxdb2 CA cert not set. Set both .Values.features.influxdb2.secretName and .Values.features.influxdb2.caSecretKey" }}
+  {{ fail "influxdb2 CA cert not set. Set both .Values.features.influxdb2.tlsSecret and .Values.features.influxdb2.caSecretKey" }}
 {{- end }}
-{{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.certSecretKey }}
+{{- if and .Values.features.influxdb2.tlsSecret .Values.features.influxdb2.certSecretKey }}
     - key: {{ .Values.features.influxdb2.certSecretKey | quote }}
       path: "cert.crt"
 {{- else }}
-  {{ fail "influxdb2 cert not set. Set both .Values.features.influxdb2.secretName and .Values.features.influxdb2.certSecretKey" }}
+  {{ fail "influxdb2 cert not set. Set both .Values.features.influxdb2.tlsSecret and .Values.features.influxdb2.certSecretKey" }}
 {{- end }}
-{{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.keySecretKey }}
+{{- if and .Values.features.influxdb2.tlsSecret .Values.features.influxdb2.keySecretKey }}
     - key: {{ .Values.features.influxdb2.keySecretKey | quote }}
       path: "cert.key"
 {{- else }}
-  {{ fail "influxdb2 cert key not set. Set both .Values.features.influxdb2.secretName and .Values.features.influxdb2.keySecretKey" }}
+  {{ fail "influxdb2 cert key not set. Set both .Values.features.influxdb2.tlsSecret and .Values.features.influxdb2.keySecretKey" }}
 {{- end }}
 {{- end }}
 {{- if and .Values.features.influxdb.enabled .Values.features.influxdb.ssl_enable }}
-{{- if and .Values.features.influxdb.secretName }}
+{{- if and .Values.features.influxdb.tlsSecret }}
 - name: influxdb-certs
   secret:
-    secretName: {{ .Values.features.influxdb.secretName | quote }}
+    secretName: {{ .Values.features.influxdb.tlsSecret | quote }}
     items:
 {{- else }}
-  {{ fail "influxdb secret not set. Set .Values.features.influxdb.secretName" }}
+  {{ fail "influxdb secret not set. Set .Values.features.influxdb.tlsSecret" }}
 {{- end }}
-{{- if and .Values.features.influxdb.secretName .Values.features.influxdb.caSecretKey }}
+{{- if and .Values.features.influxdb.tlsSecret .Values.features.influxdb.caSecretKey }}
     - key: {{ .Values.features.influxdb.caSecretKey | quote }}
       path: "ca.crt"
 {{- else }}
-  {{ fail "influxdb CA cert not set. Set both .Values.features.influxdb.secretName and .Values.features.influxdb.caSecretKey" }}
+  {{ fail "influxdb CA cert not set. Set both .Values.features.influxdb.tlsSecret and .Values.features.influxdb.caSecretKey" }}
 {{- end }}
-{{- if and .Values.features.influxdb.secretName .Values.features.influxdb.certSecretKey }}
+{{- if and .Values.features.influxdb.tlsSecret .Values.features.influxdb.certSecretKey }}
     - key: {{ .Values.features.influxdb.certSecretKey | quote }}
       path: "cert.crt"
 {{- else }}
-  {{ fail "influxdb cert not set. Set both .Values.features.influxdb.secretName and .Values.features.influxdb.certSecretKey" }}
+  {{ fail "influxdb cert not set. Set both .Values.features.influxdb.tlsSecret and .Values.features.influxdb.certSecretKey" }}
 {{- end }}
-{{- if and .Values.features.influxdb.secretName .Values.features.influxdb.keySecretKey }}
+{{- if and .Values.features.influxdb.tlsSecret .Values.features.influxdb.keySecretKey }}
     - key: {{ .Values.features.influxdb.keySecretKey | quote }}
       path: "cert.key"
 {{- else }}
-  {{ fail "influxdb cert key not set. Set both .Values.features.influxdb.secretName and .Values.features.influxdb.keySecretKey" }}
+  {{ fail "influxdb cert key not set. Set both .Values.features.influxdb.tlsSecret and .Values.features.influxdb.keySecretKey" }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/icinga-stack/charts/icinga2/templates/configmaps.yaml
+++ b/charts/icinga-stack/charts/icinga2/templates/configmaps.yaml
@@ -11,7 +11,7 @@ data:
   {{- if .Values.features.api.enabled }}
   api-users.conf: |
     {{- range $user, $settings := .Values.global.api.users }}
-    {{- if ne $user "secretName" }} # skip key secretName
+    {{- if ne $user "credSecret" }} # skip key credSecret
     {{- $permissions := $settings.permissions | default (list "*") }}
     object ApiUser {{ $user | quote }} {
       password = getenv("{{ print "ICINGA_" $user "_API_PASSWORD" | upper }}")
@@ -92,12 +92,12 @@ data:
       enable_tls = {{ .Values.features.elasticsearch.enable_tls | default "false" }}
       insecure_noverify = {{ .Values.features.elasticsearch.insecure_noverify | default "false" }}
       {{- if .Values.features.elasticsearch.enable_tls }}
-      {{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.caSecretKey .Values.features.elasticsearch.certSecretKey .Values.features.elasticsearch.keySecretKey }}
+      {{- if and .Values.features.elasticsearch.tlsSecret .Values.features.elasticsearch.caSecretKey .Values.features.elasticsearch.certSecretKey .Values.features.elasticsearch.keySecretKey }}
       ca_path = "/etc/icinga2-pki/elastic/ca.crt"
       cert_path = "/etc/icinga2-pki/elastic/cert.crt"
       key_path = "/etc/icinga2-pki/elastic/cert.key"
       {{- else }}
-        {{ fail "Elasticsearch cert secrets not set. Set .Values.features.elasticsearch.secretName, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey" }}
+        {{ fail "Elasticsearch cert secrets not set. Set .Values.features.elasticsearch.tlsSecret, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey" }}
       {{- end }}
       {{- end }}
       enable_ha = false
@@ -112,12 +112,12 @@ data:
       enable_tls = {{ .Values.features.gelf.enable_tls | default "false" }}
       insecure_noverify = {{ .Values.features.gelf.insecure_noverify | default "false" }}
       {{- if .Values.features.gelf.enable_tls }}
-      {{- if and .Values.features.gelf.secretName .Values.features.gelf.caSecretKey .Values.features.gelf.certSecretKey .Values.features.gelf.keySecretKey }}
+      {{- if and .Values.features.gelf.tlsSecret .Values.features.gelf.caSecretKey .Values.features.gelf.certSecretKey .Values.features.gelf.keySecretKey }}
       ca_path = "/etc/icinga2-pki/gelf/ca.crt"
       cert_path = "/etc/icinga2-pki/gelf/cert.crt"
       key_path = "/etc/icinga2-pki/gelf/cert.key"
       {{- else }}
-        {{ fail "GELF cert secrets not set. Set .Values.features.gelf.secretName, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey" }}
+        {{ fail "GELF cert secrets not set. Set .Values.features.gelf.tlsSecret, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey" }}
       {{- end }}
       {{- end }}
       enable_ha = false
@@ -146,13 +146,13 @@ data:
         enable_tls = {{ .Values.features.icingadb.enable_tls | default "false" }}
         insecure_noverify = {{ .Values.global.redis.insecure_noverify | default "false" }}
         {{- if .Values.features.icingadb.enable_tls }}
-        {{- if and .Values.features.icingadb.secretName .Values.features.icingadb.caSecretKey .Values.features.icingadb.certSecretKey .Values.features.icingadb.keySecretKey .Values.features.icingadb.crlSecretKey }}
+        {{- if and .Values.features.icingadb.tlsSecret .Values.features.icingadb.caSecretKey .Values.features.icingadb.certSecretKey .Values.features.icingadb.keySecretKey .Values.features.icingadb.crlSecretKey }}
         cert_path = "/etc/icinga2-pki/icingadb/cert.crt"
         key_path = "/etc/icinga2-pki/icingadb/cert.key"
         ca_path = "/etc/icinga2-pki/icingadb/ca.crt"
         crl_path = "/etc/icinga2-pki/icingadb/crl.pem"
         {{- else }}
-          {{ fail "icingadb cert secrets not set. Set .Values.features.icingadb.secretName, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey" }}
+          {{ fail "icingadb cert secrets not set. Set .Values.features.icingadb.tlsSecret, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey" }}
         {{- end }}
         {{- end }}
         cipher_list = "{{ .Values.features.icingadb.cipher_list | default "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:AES256-GCM-SHA384:AES128-GCM-SHA256" }}"
@@ -179,12 +179,12 @@ data:
       ssl_enable = {{ .Values.features.influxdb2.ssl_enable | default "false" }}
       ssl_insecure_noverify = {{ .Values.features.influxdb2.ssl_insecure_noverify | default "false" }}
       {{- if .Values.features.influxdb2.ssl_enable }}
-      {{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.caSecretKey .Values.features.influxdb2.certSecretKey .Values.features.influxdb2.keySecretKey }}
+      {{- if and .Values.features.influxdb2.tlsSecret .Values.features.influxdb2.caSecretKey .Values.features.influxdb2.certSecretKey .Values.features.influxdb2.keySecretKey }}
       ssl_ca_cert = "/etc/icinga2-pki/influxdb2/ca.crt"
       ssl_cert = "/etc/icinga2-pki/influxdb2/cert.crt"
       ssl_key = "/etc/icinga2-pki/influxdb2/cert.key"
       {{- else }}
-        {{ fail "influxdb2 cert secrets not set. Set .Values.features.influxdb2.secretName, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey" }}
+        {{ fail "influxdb2 cert secrets not set. Set .Values.features.influxdb2.tlsSecret, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey" }}
       {{- end }}
       {{- end }}
       enable_send_thresholds = {{ .Values.features.influxdb2.enable_send_thresholds | default "false" }}
@@ -219,12 +219,12 @@ data:
       ssl_enable = {{ .Values.features.influxdb.ssl_enable | default "false" }}
       ssl_insecure_noverify = {{ .Values.features.influxdb.ssl_insecure_noverify | default "false" }}
       {{- if .Values.features.influxdb.ssl_enable }}
-      {{- if and .Values.features.influxdb.secretName .Values.features.influxdb.caSecretKey .Values.features.influxdb.certSecretKey .Values.features.influxdb.keySecretKey }}
+      {{- if and .Values.features.influxdb.tlsSecret .Values.features.influxdb.caSecretKey .Values.features.influxdb.certSecretKey .Values.features.influxdb.keySecretKey }}
       ssl_ca_cert = "/etc/icinga2-pki/influxdb/ca.crt"
       ssl_cert = "/etc/icinga2-pki/influxdb/cert.crt"
       ssl_key = "/etc/icinga2-pki/influxdb/cert.key"
       {{- else }}
-        {{ fail "influxdb cert secrets not set. Set .Values.features.influxdb.secretName, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey" }}
+        {{ fail "influxdb cert secrets not set. Set .Values.features.influxdb.tlsSecret, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey" }}
       {{- end }}
       {{- end }}
       enable_send_thresholds = {{ .Values.features.influxdb.enable_send_thresholds | default "false" }}

--- a/charts/icinga-stack/charts/icinga2/templates/configmaps.yaml
+++ b/charts/icinga-stack/charts/icinga2/templates/configmaps.yaml
@@ -91,14 +91,14 @@ data:
       {{- end }}
       enable_tls = {{ .Values.features.elasticsearch.enable_tls | default "false" }}
       insecure_noverify = {{ .Values.features.elasticsearch.insecure_noverify | default "false" }}
-      {{- if and .Values.features.elasticsearch.ca_path .Values.features.elasticsearch.enable_tls }}
-      ca_path = {{ .Values.features.elasticsearch.ca_path | quote }}
+      {{- if .Values.features.elasticsearch.enable_tls }}
+      {{- if and .Values.features.elasticsearch.secretName .Values.features.elasticsearch.caSecretKey .Values.features.elasticsearch.certSecretKey .Values.features.elasticsearch.keySecretKey }}
+      ca_path = "/etc/icinga2-pki/elastic/ca.crt"
+      cert_path = "/etc/icinga2-pki/elastic/cert.crt"
+      key_path = "/etc/icinga2-pki/elastic/cert.key"
+      {{- else }}
+        {{ fail "Elasticsearch cert secrets not set. Set .Values.features.elasticsearch.secretName, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey" }}
       {{- end }}
-      {{- if and .Values.features.elasticsearch.cert_path .Values.features.elasticsearch.enable_tls }}
-      cert_path = {{ .Values.features.elasticsearch.cert_path | quote }}
-      {{- end }}
-      {{- if and .Values.features.elasticsearch.key_path .Values.features.elasticsearch.enable_tls }}
-      key_path = {{ .Values.features.elasticsearch.key_path | quote }}
       {{- end }}
       enable_ha = false
     }
@@ -111,14 +111,14 @@ data:
       enable_send_perfdata = {{ .Values.features.gelf.enable_send_perfdata | default "false" }}
       enable_tls = {{ .Values.features.gelf.enable_tls | default "false" }}
       insecure_noverify = {{ .Values.features.gelf.insecure_noverify | default "false" }}
-      {{- if and .Values.features.gelf.ca_path .Values.features.elasticsearch.enable_tls }}
-      ca_path = {{ .Values.features.gelf.ca_path | quote }}
+      {{- if .Values.features.gelf.enable_tls }}
+      {{- if and .Values.features.gelf.secretName .Values.features.gelf.caSecretKey .Values.features.gelf.certSecretKey .Values.features.gelf.keySecretKey }}
+      ca_path = "/etc/icinga2-pki/gelf/ca.crt"
+      cert_path = "/etc/icinga2-pki/gelf/cert.crt"
+      key_path = "/etc/icinga2-pki/gelf/cert.key"
+      {{- else }}
+        {{ fail "GELF cert secrets not set. Set .Values.features.gelf.secretName, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey" }}
       {{- end }}
-      {{- if and .Values.features.gelf.cert_path .Values.features.gelf.enable_tls }}
-      cert_path = {{ .Values.features.gelf.cert_path | quote }}
-      {{- end }}
-      {{- if and .Values.features.gelf.key_path .Values.features.gelf.enable_tls }}
-      key_path = {{ .Values.features.gelf.key_path | quote }}
       {{- end }}
       enable_ha = false
     }
@@ -140,22 +140,20 @@ data:
     object IcingaDB "icingadb" {
         host = {{ if .Values.global.redis.enabled -}} "{{ .Release.Name }}-redis" {{- else }}{{ .Values.global.redis.host | quote }}{{ end }}
         port = {{ if .Values.global.redis.enabled -}} 6379 {{- else }}{{ .Values.global.redis.port }}{{ end }}
-        {{- if .Values.global.redis.password }}
-        password = {{ .Values.global.redis.password | quote }}
+        {{- if .Values.features.icingadb.password }}
+        password = getenv("ICINGA_ICINGADB_PASSWORD")
         {{- end }}
-        enable_tls = {{ .Values.global.redis.enable_tls | default "false" }}
+        enable_tls = {{ .Values.features.icingadb.enable_tls | default "false" }}
         insecure_noverify = {{ .Values.global.redis.insecure_noverify | default "false" }}
-        {{- if and .Values.global.redis.ca_path .Values.global.redis.enable_tls }}
-        ca_path = {{ .Values.global.redis.ca_path | quote }}
+        {{- if .Values.features.icingadb.enable_tls }}
+        {{- if and .Values.features.icingadb.secretName .Values.features.icingadb.caSecretKey .Values.features.icingadb.certSecretKey .Values.features.icingadb.keySecretKey .Values.features.icingadb.crlSecretKey }}
+        cert_path = "/etc/icinga2-pki/icingadb/cert.crt"
+        key_path = "/etc/icinga2-pki/icingadb/cert.key"
+        ca_path = "/etc/icinga2-pki/icingadb/ca.crt"
+        crl_path = "/etc/icinga2-pki/icingadb/crl.pem"
+        {{- else }}
+          {{ fail "icingadb cert secrets not set. Set .Values.features.icingadb.secretName, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey" }}
         {{- end }}
-        {{- if and .Values.global.redis.cert_path .Values.global.redis.enable_tls }}
-        cert_path = {{ .Values.global.redis.cert_path | quote }}
-        {{- end }}
-        {{- if and .Values.global.redis.key_path .Values.global.redis.enable_tls }}
-        key_path = {{ .Values.global.redis.key_path | quote }}
-        {{- end }}
-        {{- if .Values.features.icingadb.crl_path }}
-        crl_path = {{ .Values.features.icingadb.crl_path | quote }}
         {{- end }}
         cipher_list = "{{ .Values.features.icingadb.cipher_list | default "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:AES256-GCM-SHA384:AES128-GCM-SHA256" }}"
         tls_protocolmin = {{ .Values.features.icingadb.tls_protocolmin | default "TLSv1.2" | quote }}
@@ -180,14 +178,14 @@ data:
       {{- end -}}
       ssl_enable = {{ .Values.features.influxdb2.ssl_enable | default "false" }}
       ssl_insecure_noverify = {{ .Values.features.influxdb2.ssl_insecure_noverify | default "false" }}
-      {{- if and .Values.features.influxdb2.ssl_enable .Values.features.influxdb2.ssl_ca_cert }}
-      ssl_ca_cert = {{ .Values.features.influxdb2.ssl_ca_cert | quote }}
+      {{- if .Values.features.influxdb2.ssl_enable }}
+      {{- if and .Values.features.influxdb2.secretName .Values.features.influxdb2.caSecretKey .Values.features.influxdb2.certSecretKey .Values.features.influxdb2.keySecretKey }}
+      ssl_ca_cert = "/etc/icinga2-pki/influxdb2/ca.crt"
+      ssl_cert = "/etc/icinga2-pki/influxdb2/cert.crt"
+      ssl_key = "/etc/icinga2-pki/influxdb2/cert.key"
+      {{- else }}
+        {{ fail "influxdb2 cert secrets not set. Set .Values.features.influxdb2.secretName, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey" }}
       {{- end }}
-      {{- if and .Values.features.influxdb2.ssl_enable .Values.features.influxdb2.ssl_cert }}
-      ssl_cert = {{ .Values.features.influxdb2.ssl_cert | quote }}
-      {{- end }}
-      {{- if and .Values.features.influxdb2.ssl_enable .Values.features.influxdb2.ssl_key }}
-      ssl_key = {{ .Values.features.influxdb2.ssl_key | quote }}
       {{- end }}
       enable_send_thresholds = {{ .Values.features.influxdb2.enable_send_thresholds | default "false" }}
       enable_send_metadata = {{ .Values.features.influxdb2.enable_send_metadata | default "false" }}
@@ -220,14 +218,14 @@ data:
       {{- end }}
       ssl_enable = {{ .Values.features.influxdb.ssl_enable | default "false" }}
       ssl_insecure_noverify = {{ .Values.features.influxdb.ssl_insecure_noverify | default "false" }}
-      {{- if and .Values.features.influxdb.ssl_enable .Values.features.influxdb.ssl_ca_cert }}
-      ssl_ca_cert = {{ .Values.features.influxdb.ssl_ca_cert | quote }}
+      {{- if .Values.features.influxdb.ssl_enable }}
+      {{- if and .Values.features.influxdb.secretName .Values.features.influxdb.caSecretKey .Values.features.influxdb.certSecretKey .Values.features.influxdb.keySecretKey }}
+      ssl_ca_cert = "/etc/icinga2-pki/influxdb/ca.crt"
+      ssl_cert = "/etc/icinga2-pki/influxdb/cert.crt"
+      ssl_key = "/etc/icinga2-pki/influxdb/cert.key"
+      {{- else }}
+        {{ fail "influxdb cert secrets not set. Set .Values.features.influxdb.secretName, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey" }}
       {{- end }}
-      {{- if and .Values.features.influxdb.ssl_enable .Values.features.influxdb.ssl_cert }}
-      ssl_cert = {{ .Values.features.influxdb.ssl_cert | quote }}
-      {{- end }}
-      {{- if and .Values.features.influxdb.ssl_enable .Values.features.influxdb.ssl_key }}
-      ssl_key = {{ .Values.features.influxdb.ssl_key | quote }}
       {{- end }}
       enable_send_thresholds = {{ .Values.features.influxdb.enable_send_thresholds | default "false" }}
       enable_send_metadata = {{ .Values.features.influxdb.enable_send_metadata | default "false" }}

--- a/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
+++ b/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
@@ -51,6 +51,7 @@ spec:
               mountPath: /etc/icinga2/features-enabled
             - name: {{ include "icinga2.fullname" . }}-config
               mountPath: /etc/icinga2
+            {{- include "icinga2.secretMounts" . | indent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       initContainers:
@@ -75,6 +76,7 @@ spec:
               {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
               {{- end }}
+            {{- include "icinga2.secretMounts" . | indent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
@@ -88,6 +90,7 @@ spec:
         - name: data
           emptyDir: {}
         {{- end }}
+        {{- include "icinga2.secretVolumes" . | indent 8 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/icinga-stack/charts/icinga2/values.yaml
+++ b/charts/icinga-stack/charts/icinga2/values.yaml
@@ -85,7 +85,7 @@ features:
     # enable_send_perfdata: false
     # flush_threshold: 1024
     # flush_interval: 10s
-    # secretName: icinga-elasticsearch-secret # used for username and password
+    # secretName: icinga-elasticsearch-secret # used for username, password and certs
     # username:
     #   value: elastic # Specify username
     #   secretKey: username # Or use existing secret
@@ -94,9 +94,9 @@ features:
     #    secretKey: password # Or use existing secret
     # enable_tls: false
     # insecure_noverify: false
-    # ca_path: /etc/icinga2/pki/elastic-ca.crt
-    # cert_path: /etc/icinga2/pki/elastic-cert.crt
-    # key_path: /etc/icinga2/pki/elastic-cert.key
+    # caSecretKey: # Secret key to mount at /etc/icinga2-pki/elastic-ca.crt
+    # certSecretKey: # Secret key to mount at /etc/icinga2-pki/elastic-cert.crt
+    # keySecretKey: # Secret key to mount at /etc/icinga2-pki/elastic-cert.key
 
   # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#gelfwriter
   gelf:
@@ -107,9 +107,10 @@ features:
     # enable_send_perfdata: false
     # enable_tls: false
     # insecure_noverify: false
-    # ca_path: /etc/icinga2/pki/gelf-ca.crt
-    # cert_path: /etc/icinga2/pki/gelf-cert.crt
-    # key_path: /etc/icinga2/pki/gelf-cert.key
+    # secretName: # used for certs
+    # caSecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/ca.crt
+    # certSecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/cert.crt
+    # keySecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/cert.key
 
   # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#graphitewriter
   graphite:
@@ -124,12 +125,15 @@ features:
   # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#icingadb
   icingadb:
     enabled: true
-    # password:
+    # secretName: # used for password and certs
+    # password: 
+    #   value: password # Specify password
+    #   secretKey: password # Or use existing secret
     # enable_tls: false
-    # cert_path: /etc/icinga2/pki/icingadb-cert.crt
-    # key_path: /etc/icinga2/pki/icingadb-cert.key
-    # ca_path: /etc/icinga2/pki/icingadb-ca.crt
-    # crl_path: /etc/icinga2/pki/icingadb-crl.pem
+    # certSecretKey: # Secret key to mount at /etc/icinga2-pki/icingadb/cert.crt
+    # keySecretKey: # Secret key to mount at /etc/icinga2-pki/icingadb/cert.key
+    # caSecretKey: # Secret key to mount at /etc/icinga2-pki/icingadb/ca.crt
+    # crlSecretKey: # Secret key to mount at /etc/icinga2/pki/icingadb/crl.pem
     # cipher_list: ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:AES256-GCM-SHA384:AES128-GCM-SHA256
     # tls_protocolmin: TLSv1.2
     # insecure_noverify: false
@@ -142,15 +146,15 @@ features:
     # port: 8086
     # organization: monitoring
     # bucket: icinga2
+    # secretName: secretName # Used for auth_token and certs
     # auth_token:
     #   value: securitytoken # Specify auth token value
-    #   secretName: secretName # Or use existing secret
     #   secretKey: secretKey
     # ssl_enable: false
     # ssl_insecure_noverify: false
-    # ssl_ca_cert: /etc/icinga2/pki/influxdb2-ca.crt
-    # ssl_cert: /etc/icinga2/pki/influxdb2-cert.crt
-    # ssl_key: /etc/icinga2/pki/influxdb2-cert.key
+    # caSecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb2/ca.crt
+    # certSecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb2/cert.crt
+    # keySecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb2/cert.key
     # enable_send_thresholds: false
     # enable_send_metadata: false
     # flush_threshold: 1024
@@ -193,9 +197,9 @@ features:
     #     secretKey: # Or use existing secret
     # ssl_enable: false
     # ssl_insecure_noverify: false
-    # ssl_ca_cert: /etc/icinga2/pki/influxdb-ca.crt
-    # ssl_cert: /etc/icinga2/pki/influxdb-cert.crt
-    # ssl_key: /etc/icinga2/pki/influxdb-cert.key
+    # caSecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb/ca.crt
+    # certSecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb/cert.crt
+    # keySecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb/cert.key
     # enable_send_thresholds: false
     # enable_send_metadata: false
     # flush_threshold: 1024
@@ -214,6 +218,7 @@ features:
           hostname = "$host.name$"
           service = "$service.name$"
         }
+      }
     
   # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#filelogger
   mainlog:

--- a/charts/icinga-stack/charts/icinga2/values.yaml
+++ b/charts/icinga-stack/charts/icinga2/values.yaml
@@ -32,7 +32,7 @@ config:
   zone_name: master
   ticket_salt:
     value: # Add random (long!) string here
-    secretName: # Or use existing secret
+    credSecret: # Or use existing secret
     secretKey:
   disable_confd: true
 
@@ -85,7 +85,8 @@ features:
     # enable_send_perfdata: false
     # flush_threshold: 1024
     # flush_interval: 10s
-    # secretName: icinga-elasticsearch-secret # used for username, password and certs
+    # credSecret: # used for credentials
+    # tlsSecret: # used for certificates
     # username:
     #   value: elastic # Specify username
     #   secretKey: username # Or use existing secret
@@ -107,7 +108,7 @@ features:
     # enable_send_perfdata: false
     # enable_tls: false
     # insecure_noverify: false
-    # secretName: # used for certs
+    # tlsSecret: # used for certificates
     # caSecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/ca.crt
     # certSecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/cert.crt
     # keySecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/cert.key
@@ -125,7 +126,8 @@ features:
   # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#icingadb
   icingadb:
     enabled: true
-    # secretName: # used for password and certs
+    # credSecret: # used for credentials
+    # tlsSecret: # used for certificates
     # password: 
     #   value: password # Specify password
     #   secretKey: password # Or use existing secret
@@ -146,7 +148,8 @@ features:
     # port: 8086
     # organization: monitoring
     # bucket: icinga2
-    # secretName: secretName # Used for auth_token and certs
+    # credSecret: # used for credentials
+    # tlsSecret: # used for certificates
     # auth_token:
     #   value: securitytoken # Specify auth token value
     #   secretKey: secretKey
@@ -181,7 +184,8 @@ features:
     # host: influx
     # port: 8086
     # database: icinga2
-    # secretName: # existing secret used for influxdb credentials and basic_auth credentials
+    # credSecret: # existing secret used for influxdb credentials and basic_auth credentials
+    # tlsSecret: # used for certificates
     # username:
     #   value: # Specify username
     #   secretKey: # Or use existing secret

--- a/charts/icinga-stack/charts/icingadb/templates/deployment.yaml
+++ b/charts/icinga-stack/charts/icingadb/templates/deployment.yaml
@@ -42,24 +42,24 @@ spec:
             - name: ICINGADB_DATABASE_USER
               {{- if and .Values.global.databases.icingadb.username .Values.global.databases.icingadb.username.value }}
               value: {{ .Values.global.databases.icingadb.username.value | quote }}
-              {{- else if and .Values.global.databases.icingadb.username .Values.global.databases.icingadb.secretName .Values.global.databases.icingadb.username.secretKey }}
+              {{- else if and .Values.global.databases.icingadb.username .Values.global.databases.icingadb.credSecret .Values.global.databases.icingadb.username.secretKey }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.databases.icingadb.secretName | quote }}
+                  name: {{ .Values.global.databases.icingadb.credSecret | quote }}
                   key: {{ .Values.global.databases.icingadb.username.secretKey | quote }}
               {{- else }}
-              {{ fail ".Values.global.databases.icingadb.username not set. Set either .Values.global.databases.icingadb.username.value or .Values.global.databases.icingadb.secretName and .Values.global.databases.icingadb.username.secretKey" }}
+              {{ fail ".Values.global.databases.icingadb.username not set. Set either .Values.global.databases.icingadb.username.value or .Values.global.databases.icingadb.credSecret and .Values.global.databases.icingadb.username.secretKey" }}
               {{- end }}
             - name: ICINGADB_DATABASE_PASSWORD
               {{- if and .Values.global.databases.icingadb.password .Values.global.databases.icingadb.password.value }}
               value: {{ .Values.global.databases.icingadb.password.value | quote }}
-              {{- else if and .Values.global.databases.icingadb.password .Values.global.databases.icingadb.secretName .Values.global.databases.icingadb.password.secretKey }}
+              {{- else if and .Values.global.databases.icingadb.password .Values.global.databases.icingadb.credSecret .Values.global.databases.icingadb.password.secretKey }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.databases.icingadb.secretName | quote }}
+                  name: {{ .Values.global.databases.icingadb.credSecret | quote }}
                   key: {{ .Values.global.databases.icingadb.password.secretKey | quote }}
               {{- else }}
-              {{ fail ".Values.global.databases.icingadb.password not set. Set either .Values.global.databases.icingadb.password.value or .Values.global.databases.icingadb.secretName and .Values.global.databases.icingadb.password.secretKey" }}
+              {{ fail ".Values.global.databases.icingadb.password not set. Set either .Values.global.databases.icingadb.password.value or .Values.global.databases.icingadb.credSecret and .Values.global.databases.icingadb.password.secretKey" }}
               {{- end }}
             - name: ICINGADB_DATABASE_DATABASE
               value: {{ .Values.global.databases.icingadb.database | default "mysql" | quote }}

--- a/charts/icinga-stack/charts/icingaweb2/templates/_icingaweb-config.tpl
+++ b/charts/icinga-stack/charts/icingaweb2/templates/_icingaweb-config.tpl
@@ -13,13 +13,13 @@
 - name: icingaweb.modules.director.kickstart.config.password
 {{- if and .Values.global.api.users.director.password .Values.global.api.users.director.password.value }}
   value: {{ .Values.global.api.users.director.password.value | quote }}
-{{- else if and .Values.global.api.users.secretName .Values.global.api.users.director.password .Values.global.api.users.director.password.secretKey }}
+{{- else if and .Values.global.api.users.credSecret .Values.global.api.users.director.password .Values.global.api.users.director.password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.global.api.users.secretName | quote }}
+      name: {{ .Values.global.api.users.credSecret | quote }}
       key: {{ .Values.global.api.users.director.password.secretKey | quote }}
 {{- else }}
-{{ fail "director api user password not set. Set either .Values.global.api.users.director.password.value or .Values.global.api.users.secretName and .Values.global.api.users.director.password.secretKey" }}
+{{ fail "director api user password not set. Set either .Values.global.api.users.director.password.value or .Values.global.api.users.credSecret and .Values.global.api.users.director.password.secretKey" }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -30,13 +30,13 @@
 - name: "icingaweb.passwords.icingaweb2.{{ .Values.auth.admin_user}}"
 {{- if .Values.auth.admin_password.value }}
   value: {{ .Values.auth.admin_password.value | quote }}
-{{- else if and .Values.auth.admin_password.secretName .Values.auth.admin_password.secretKey }}
+{{- else if and .Values.auth.admin_password.credSecret .Values.auth.admin_password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.auth.admin_password.secretName | quote }}
+      name: {{ .Values.auth.admin_password.credSecret | quote }}
       key: {{ .Values.auth.admin_password.secretKey | quote }}
 {{- else }}
-{{ fail "IcingaWeb2 auth admin password not set. Set either .Values.icingaweb2.auth.admin_password.value or .Values.icingaweb2.auth.admin_password.secretName and .Values.icingaweb2.auth.admin_password.secretKey" }}
+{{ fail "IcingaWeb2 auth admin password not set. Set either .Values.icingaweb2.auth.admin_password.value or .Values.icingaweb2.auth.admin_password.credSecret and .Values.icingaweb2.auth.admin_password.secretKey" }}
 {{- end}}
 - name: icingaweb.config.global.config_resource
   value: {{ .Values.auth.resource | default .Values.global.databases.icingaweb2.database | quote }}
@@ -70,13 +70,13 @@
 - name: icingaweb.modules.icingadb.commandtransports.icinga2.password
 {{- if and .Values.global.api.users.icingaweb.password .Values.global.api.users.icingaweb.password.value }}
   value: {{ .Values.global.api.users.icingaweb.password.value | quote }}
-{{- else if and .Values.global.api.users.secretName .Values.global.api.users.icingaweb.password .Values.global.api.users.icingaweb.password.secretKey }}
+{{- else if and .Values.global.api.users.credSecret .Values.global.api.users.icingaweb.password .Values.global.api.users.icingaweb.password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.global.api.users.secretName | quote }}
+      name: {{ .Values.global.api.users.credSecret | quote }}
       key: {{ .Values.global.api.users.icingaweb.password.secretKey | quote }}
 {{- else }}
-{{ fail "icingaweb API user password not set. Set either .Values.global.api.users.icingaweb.password.value or .Values.global.api.users.secretName and .Values.global.api.users.icingaweb.password.secretKey" }}
+{{ fail "icingaweb API user password not set. Set either .Values.global.api.users.icingaweb.password.value or .Values.global.api.users.credSecret and .Values.global.api.users.icingaweb.password.secretKey" }}
 {{- end }}
 {{- end }}
 {{- if .Values.modules.audit.enabled }}
@@ -100,19 +100,19 @@
 - name: icingaweb.modules.graphite.config.graphite.user
 {{- if .Values.modules.graphite.graphite.user.value }}
   value: {{ .Values.modules.graphite.graphite.user.value | quote }}
-{{- else if and .Values.modules.graphite.graphite.secretName .Values.modules.graphite.graphite.user.secretKey }}
+{{- else if and .Values.modules.graphite.graphite.credSecret .Values.modules.graphite.graphite.user.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.modules.graphite.graphite.secretName | quote }}
+      name: {{ .Values.modules.graphite.graphite.credSecret | quote }}
       key: {{ .Values.modules.graphite.graphite.user.secretKey | quote }}
 {{- end }}
 - name: icingaweb.modules.graphite.config.graphite.password
 {{- if .Values.modules.graphite.graphite.password.value }}
   value: {{ .Values.modules.graphite.graphite.password.value | quote}}
-{{- else if and .Values.modules.graphite.graphite.secretName .Values.modules.graphite.graphite.password.secretKey }}
+{{- else if and .Values.modules.graphite.graphite.credSecret .Values.modules.graphite.graphite.password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ .Values.modules.graphite.graphite.secretName | quote }}
+      name: {{ .Values.modules.graphite.graphite.credSecret | quote }}
       key: {{ .Values.modules.graphite.graphite.password.secretKey | quote }}
 {{- end }}
 {{- end }}

--- a/charts/icinga-stack/charts/icingaweb2/templates/_resources.tpl
+++ b/charts/icinga-stack/charts/icingaweb2/templates/_resources.tpl
@@ -17,10 +17,10 @@
 - name: icingaweb.resources.{{ $settings.database }}.username
   {{- if and $settings.username $settings.username.value }}
   value: {{ $settings.username.value | quote }}
-  {{- else if and $settings.username $settings.secretName $settings.username.secretKey }}
+  {{- else if and $settings.username $settings.credSecret $settings.username.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ $settings.secretName | quote }}
+      name: {{ $settings.credSecret | quote }}
       key: {{ $settings.username.secretKey | quote }}
   {{- else }}
   value: "mysql"
@@ -28,10 +28,10 @@
 - name: icingaweb.resources.{{ $settings.database }}.password
   {{- if and $settings.password $settings.password.value }}
   value: {{ $settings.password.value | quote }}
-  {{- else if and $settings.password $settings.secretName $settings.password.secretKey }}
+  {{- else if and $settings.password $settings.credSecret $settings.password.secretKey }}
   valueFrom:
     secretKeyRef:
-      name: {{ $settings.secretName | quote }}
+      name: {{ $settings.credSecret | quote }}
       key: {{ $settings.password.secretKey | quote }}
   {{- else }}
   value: "mysql"

--- a/charts/icinga-stack/charts/icingaweb2/values.yaml
+++ b/charts/icinga-stack/charts/icingaweb2/values.yaml
@@ -36,7 +36,7 @@ auth:
   admin_user: icingaweb
   admin_password:
     value: # Add a password here
-    secretName: # Or use existing secret
+    credSecret: # Or use existing secret
     secretKey:
 
 modules:
@@ -64,7 +64,7 @@ modules:
     enabled: false
     graphite:
       url: graphite.example.com
-      secretName: # Existing secret used for user and password
+      credSecret: # Existing secret used for user and password
       user:
         value: # Specify username
         secretKey: # Or use existing secret

--- a/charts/icinga-stack/docs/configuration.md
+++ b/charts/icinga-stack/docs/configuration.md
@@ -10,6 +10,8 @@ For configuration of IcingaWeb2's different **modules**, please see the section 
 
 Sensible values can be set directly using `.value` key or by using Kubernetes secrets. Values that can be configured using secrets have parameters holding secret name and key listed in tables below.
 
+Certificates used by Icinga features are projected in containers using kubernetes secrets. Please see [values.yaml](../values.yaml) for configuration.
+
 ### Required values
 
 These values **must** be set for the chart to install successfully. Therefore, no defaults are provided. Installation will fail if these values are not set.

--- a/charts/icinga-stack/docs/configuration.md
+++ b/charts/icinga-stack/docs/configuration.md
@@ -20,10 +20,10 @@ The values can be set in the chart's `values.yaml` file or via the `--set` flag 
 
 | Parameter | Description | Remarks | Kubernetes secret parameters |
 | --------- | ----------- | ------- | ---------------------------- |
-| `icinga2.config.ticket_salt.value` | Salt used to generate API tickets for satellites and agents | - | `icinga2.config.ticket_salt.secretName`, `icinga2.config.ticket_salt.secretKey` |
-| `icingaweb2.auth.admin_password.value` | Password for the Icinga Web 2 admin user | Only needs to be set if Icingaweb2 is `enabled` | `icingaweb2.auth.admin_password.secretName`, `icingaweb2.auth.admin_password.secretKey` |
-| `global.api.users.director.password.value` | Password for the Icinga Director API user | Only needs to be set if Director is `enabled` | `global.api.users.secretName`, `global.api.users.director.password.secretKey` |
-| `global.api.users.icingaweb.password.value` | Password for the Icingaweb2 API user| Only needs to be set if Icingaweb2 is `enabled` | `global.api.users.secretName`, `global.api.users.icingaweb.password.secretKey` |
+| `icinga2.config.ticket_salt.value` | Salt used to generate API tickets for satellites and agents | - | `icinga2.config.ticket_salt.credSecret`, `icinga2.config.ticket_salt.secretKey` |
+| `icingaweb2.auth.admin_password.value` | Password for the Icinga Web 2 admin user | Only needs to be set if Icingaweb2 is `enabled` | `icingaweb2.auth.admin_password.credSecret`, `icingaweb2.auth.admin_password.secretKey` |
+| `global.api.users.director.password.value` | Password for the Icinga Director API user | Only needs to be set if Director is `enabled` | `global.api.users.credSecret`, `global.api.users.director.password.secretKey` |
+| `global.api.users.icingaweb.password.value` | Password for the Icingaweb2 API user| Only needs to be set if Icingaweb2 is `enabled` | `global.api.users.credSecret`, `global.api.users.icingaweb.password.secretKey` |
 
 ### Global values
 
@@ -36,8 +36,8 @@ These values are used by multiple (sub-)charts and therefore need to be set in t
 | `global.api.users.director.permissions` | Permissions of the Icinga2 API user for Director | `[]string` | `["*"]` |
 | `global.api.users.icingaweb.permissions` | Permissions of the Icinga2 API user for Icingaweb2 | `[]string` | `["*"]` |
 | `global.databases.<database>.database` | Name of the respective database | `string` | `<database>db`|
-| `global.databases.<database>.username.value` | Username for the respective database. Can be set from secret defined by `global.databases.<database>.secretName` and `global.databases.<database>.username.secretKey` | `string` | **not set** |  |
-| `global.databases.<database>.password.value` | Password for the respective database. Can be set from secret defined by `global.databases.<database>.secretName` and `global.databases.<database>.password.secretKey` | `string` | **not set** |  |
+| `global.databases.<database>.username.value` | Username for the respective database. Can be set from secret defined by `global.databases.<database>.credSecret` and `global.databases.<database>.username.secretKey` | `string` | **not set** |  |
+| `global.databases.<database>.password.value` | Password for the respective database. Can be set from secret defined by `global.databases.<database>.credSecret` and `global.databases.<database>.password.secretKey` | `string` | **not set** |  |
 | `global.databases.<database>.enabled` | Whether or not the database should get deployed in-cluster | `boolean` | **varies** |
 | `global.databases.<database>.host` | Hostname of the respective database | `string` | **not set** |
 | `global.databases.<database>.port` | Port of the respective database | `number` | `3306` |
@@ -78,7 +78,7 @@ These values are used by the Icinga2 sub-chart. For configuration of Icinga2's d
 | `icinga2.config.node_name` | Name of the Icinga2 node | `string` | `icinga2-master` |
 | `icinga2.config.zone_name` | Name of the Icinga2 zone | `string` | `master` |
 | `icinga2.config.disable_confd` | Disables the `include_recursive "conf.d"` directive in icinga2.conf | `boolean` | `true` |
-| `icinga2.config.ticket_salt.value` | Salt used to generate API tickets for satellites and agents. Can be set from secret specified in `icinga2.config.ticket_salt.secretName` and `icinga2.config.ticket_salt.secretKey` | `string` | **not set** |
+| `icinga2.config.ticket_salt.value` | Salt used to generate API tickets for satellites and agents. Can be set from secret specified in `icinga2.config.ticket_salt.credSecret` and `icinga2.config.ticket_salt.secretKey` | `string` | **not set** |
 | `icinga2.features.<feature>.enabled` | Whether or not the respective feature should be enabled | `boolean` | **varies** |
 | `icinga2.persistence.enabled` | Whether or not the Icinga2 deployment should use a persistent volume | `boolean` | `false` |
 | `icinga2.persistence.size` | Size of the persistent volume | `string` | `5Gi` |
@@ -148,7 +148,7 @@ These values are used by the IcingaWeb2 sub-chart. For configuration of Icingawe
 | `icingaweb2.ingress.tls[].secretName` | Secret name of the IcingaWeb2 ingress | `string` | **not set** |
 | `icingaweb2.auth.type` | Type of the IcingaWeb2 authentication | `string` | `db` |
 | `icingaweb2.auth.admin_user` | Admin user of the IcingaWeb2 authentication | `string` | `icingaweb` |
-| `icingaweb2.auth.admin_password.value` | Admin password of the IcingaWeb2 authentication. Can be set from secret specified in `icingaweb2.auth.admin_password.secretName` and `icingaweb2.auth.admin_password.secretKey` | `string` | **not set** |
+| `icingaweb2.auth.admin_password.value` | Admin password of the IcingaWeb2 authentication. Can be set from secret specified in `icingaweb2.auth.admin_password.credSecret` and `icingaweb2.auth.admin_password.secretKey` | `string` | **not set** |
 | `icingaweb2.modules.<module>.enabled` | Whether or not to enable the IcingaWeb2 module | `boolean` | **varies** |
 | `icingaweb2.resources` | Resources of the IcingaWeb2 deployment | `map[string]string` | `{}` |
 | `icingaweb2.nodeSelector` | Node selector of the IcingaWeb2 deployment | `map[string]string` | `{}` |

--- a/charts/icinga-stack/templates/internal-databases.yaml
+++ b/charts/icinga-stack/templates/internal-databases.yaml
@@ -35,24 +35,24 @@ spec:
             - name: MARIADB_USER
               {{- if and $settings.username $settings.username.value }}
               value: {{ $settings.username.value | quote }}
-              {{- else if and $settings.username $settings.secretName $settings.username.secretKey }}
+              {{- else if and $settings.username $settings.credSecret $settings.username.secretKey }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ $settings.secretName | quote }}
+                  name: {{ $settings.credSecret | quote }}
                   key: {{ $settings.username.secretKey | quote }}
               {{- else }}
-              {{ fail (print $resource " username not set. Set either .Values.global.databases." $resource ".username.value or .Values.global.databases." $resource ".secretName and .Values.global.databases." $resource ".username.secretKey") }}
+              {{ fail (print $resource " username not set. Set either .Values.global.databases." $resource ".username.value or .Values.global.databases." $resource ".credSecret and .Values.global.databases." $resource ".username.secretKey") }}
               {{- end }}
             - name: MARIADB_PASSWORD
               {{- if and $settings.password $settings.password.value }}
               value: {{ $settings.password.value | quote }}
-              {{- else if and $settings.password $settings.secretName $settings.password.secretKey }}
+              {{- else if and $settings.password $settings.credSecret $settings.password.secretKey }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ $settings.secretName | quote }}
+                  name: {{ $settings.credSecret | quote }}
                   key: {{ $settings.password.secretKey | quote }}
               {{- else }}
-              {{ fail (print $resource " password not set. Set either .Values.global.databases." $resource ".password.value or .Values.global.databases." $resource ".secretName and .Values.global.databases." $resource ".password.secretKey") }}
+              {{ fail (print $resource " password not set. Set either .Values.global.databases." $resource ".password.value or .Values.global.databases." $resource ".credSecret and .Values.global.databases." $resource ".password.secretKey") }}
               {{- end }}
           volumeMounts:
             {{- if $settings.persistence.enabled }}

--- a/charts/icinga-stack/tests/global_database_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/global_database_statefulset_test.yaml
@@ -70,13 +70,13 @@ tests:
             password:
               value: insecuredirectorpassword
           icingaweb2:
-            secretName: database-icingaweb2
+            credSecret: database-icingaweb2
             username:
               secretKey: username
             password:
               secretKey: password
           icingadb:
-            secretName: database-icingadb
+            credSecret: database-icingadb
             username:
               secretKey: username
             password:
@@ -109,17 +109,17 @@ tests:
       global:
         databases:
           director:
-            secretName: database-director
+            credSecret: database-director
             username:
               secretKey: username
           icingaweb2:
-            secretName: database-icingaweb2
+            credSecret: database-icingaweb2
             username:
               secretKey: username
             password:
               secretKey: password
           icingadb:
-            secretName: database-icingadb
+            credSecret: database-icingadb
             username:
               secretKey: username
             password:
@@ -128,7 +128,7 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "director password not set. Set either .Values.global.databases.director.password.value or .Values.global.databases.director.secretName and .Values.global.databases.director.password.secretKey"
+          errorMessage: "director password not set. Set either .Values.global.databases.director.password.value or .Values.global.databases.director.credSecret and .Values.global.databases.director.password.secretKey"
   
   # IcingaDB DB
   - it: deploys an IcingaDB database StatefulSet using values

--- a/charts/icinga-stack/tests/icinga2_configmaps_test.yaml
+++ b/charts/icinga-stack/tests/icinga2_configmaps_test.yaml
@@ -32,7 +32,7 @@ tests:
         features:
           elasticsearch:
             enabled: true
-            secretName: icinga-elasticsearch
+            credSecret: icinga-elasticsearch
             username:
               secretKey: elastic-username
             password:
@@ -60,7 +60,8 @@ tests:
         features:
           elasticsearch:
             enabled: true
-            secretName: icinga-elasticsearch
+            credSecret: icinga-elasticsearch-creds
+            tlsSecret: icinga-elasticsearch-certs
             username:
               secretKey: elastic-username
             password:
@@ -104,7 +105,7 @@ tests:
         features:
           elasticsearch:
             enabled: true
-            secretName: icinga-elasticsearch
+            tlsSecret: icinga-elasticsearch-certs
             username:
               secretKey: elastic-username
             password:
@@ -115,7 +116,7 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "Elasticsearch cert secrets not set. Set .Values.features.elasticsearch.secretName, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey"
+          errorMessage: "Elasticsearch cert secrets not set. Set .Values.features.elasticsearch.tlsSecret, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey"
 
   - it: Icinga2 configmap gelf tls test
     values:
@@ -125,7 +126,7 @@ tests:
         features:
           gelf:
             enabled: true
-            secretName: icinga-gelf
+            tlsSecret: icinga-gelf
             enable_tls: true
             caSecretKey: gelf-ca-key
             certSecretKey: gelf-cert-key
@@ -157,14 +158,14 @@ tests:
         features:
           gelf:
             enabled: true
-            secretName: icinga-gelf
+            tlsSecret: icinga-gelf
             enable_tls: true
             caSecretKey: gelf-gelf-key
     release:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "GELF cert secrets not set. Set .Values.features.gelf.secretName, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey"
+          errorMessage: "GELF cert secrets not set. Set .Values.features.gelf.tlsSecret, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey"
 
   - it: Icinga2 configmap icingadb test without password
     values:
@@ -194,7 +195,7 @@ tests:
         features:
           icingadb:
             enabled: true
-            secretName: icinga-icingadb-secret
+            credSecret: icinga-icingadb-secret
             password:
               secretKey: password-key
     release:
@@ -216,7 +217,7 @@ tests:
         features:
           icingadb:
             enabled: true
-            secretName: icinga-icingadb
+            tlsSecret: icinga-icingadb
             enable_tls: true
             caSecretKey: icingadb-ca-key
             certSecretKey: icingadb-cert-key
@@ -253,7 +254,7 @@ tests:
         features:
           icingadb:
             enabled: true
-            secretName: icinga-icingadb
+            tlsSecret: icinga-icingadb
             enable_tls: true
             caSecretKey: icingadb-ca-key
             keySecretKey: icingadb-key-key
@@ -262,7 +263,7 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "icingadb cert secrets not set. Set .Values.features.icingadb.secretName, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey"
+          errorMessage: "icingadb cert secrets not set. Set .Values.features.icingadb.tlsSecret, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey"
 
   - it: Icinga2 configmap influxdb2 ssl test
     values:
@@ -272,7 +273,7 @@ tests:
         features:
           influxdb2:
             enabled: true
-            secretName: icinga-influxdb2
+            tlsSecret: icinga-influxdb2
             ssl_enable: true
             caSecretKey: influxdb2-ca-key
             certSecretKey: influxdb2-cert-key
@@ -304,7 +305,7 @@ tests:
         features:
           influxdb2:
             enabled: true
-            secretName: icinga-influxdb2
+            tlsSecret: icinga-influxdb2
             ssl_enable: true
             caSecretKey: influxdb2-ca-key
             keySecretKey: influxdb2-key-key
@@ -313,7 +314,7 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "influxdb2 cert secrets not set. Set .Values.features.influxdb2.secretName, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey"
+          errorMessage: "influxdb2 cert secrets not set. Set .Values.features.influxdb2.tlsSecret, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey"
 
   - it: Icinga2 configmap influxdb ssl test
     values:
@@ -323,7 +324,7 @@ tests:
         features:
           influxdb:
             enabled: true
-            secretName: icinga-influxdb
+            tlsSecret: icinga-influxdb
             ssl_enable: true
             caSecretKey: influxdb-ca-key
             certSecretKey: influxdb-cert-key
@@ -355,7 +356,7 @@ tests:
         features:
           influxdb:
             enabled: true
-            secretName: icinga-influxdb
+            tlsSecret: icinga-influxdb
             ssl_enable: true
             caSecretKey: influxdb-ca-key
             keySecretKey: influxdb-key-key
@@ -364,7 +365,7 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "influxdb cert secrets not set. Set .Values.features.influxdb.secretName, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey"
+          errorMessage: "influxdb cert secrets not set. Set .Values.features.influxdb.tlsSecret, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey"
 
   - it: Icinga2 configmap influxdb2 test
     values:
@@ -375,7 +376,7 @@ tests:
           influxdb2:
             enabled: true
             auth_token:
-              secretName: icinga-influxdb2
+              tlsSecret: icinga-influxdb2
               secretKey: authToken
     release:
       name: my-icinga
@@ -396,7 +397,7 @@ tests:
         features:
           influxdb:
             enabled: true
-            secretName: icinga-influxdb
+            credSecret: icinga-influxdb
             username:
               secretKey: influxdb-username
             password:
@@ -451,7 +452,7 @@ tests:
         features:
           influxdb:
             enabled: true
-            secretName: icinga-influxdb
+            credSecret: icinga-influxdb
             basic_auth:
               username:
                 secretKey: influxdb-basic-auth-username

--- a/charts/icinga-stack/tests/icinga2_configmaps_test.yaml
+++ b/charts/icinga-stack/tests/icinga2_configmaps_test.yaml
@@ -52,6 +52,320 @@ tests:
           pattern: password = getenv\("ICINGA_ELASTICSEARCH_PASSWORD"\)
         documentIndex: 1
 
+  - it: Icinga2 configmap elasticsearch tls test
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          elasticsearch:
+            enabled: true
+            secretName: icinga-elasticsearch
+            username:
+              secretKey: elastic-username
+            password:
+              secretKey: elastic-password
+            enable_tls: true
+            caSecretKey: elastic-ca-key
+            certSecretKey: elastic-cert-key
+            keySecretKey: elastic-key-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - matchRegex:
+          path: data["elasticsearch.conf"]
+          pattern: username = getenv\("ICINGA_ELASTICSEARCH_USERNAME"\)
+        documentIndex: 1
+      - matchRegex:
+          path: data["elasticsearch.conf"]
+          pattern: password = getenv\("ICINGA_ELASTICSEARCH_PASSWORD"\)
+        documentIndex: 1
+      - matchRegex:
+          path: data["elasticsearch.conf"]
+          pattern: ca_path = "/etc/icinga2-pki/elastic/ca.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["elasticsearch.conf"]
+          pattern: cert_path = "/etc/icinga2-pki/elastic/cert.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["elasticsearch.conf"]
+          pattern: key_path = "/etc/icinga2-pki/elastic/cert.key"
+        documentIndex: 1
+
+  - it: Icinga2 configmap elasticsearch tls failure
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          elasticsearch:
+            enabled: true
+            secretName: icinga-elasticsearch
+            username:
+              secretKey: elastic-username
+            password:
+              secretKey: elastic-password
+            enable_tls: true
+            caSecretKey: elastic-ca-key
+    release:
+      name: my-icinga
+    asserts:
+      - failedTemplate:
+          errorMessage: "Elasticsearch cert secrets not set. Set .Values.features.elasticsearch.secretName, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey"
+
+  - it: Icinga2 configmap gelf tls test
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          gelf:
+            enabled: true
+            secretName: icinga-gelf
+            enable_tls: true
+            caSecretKey: gelf-ca-key
+            certSecretKey: gelf-cert-key
+            keySecretKey: gelf-key-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - matchRegex:
+          path: data["gelf.conf"]
+          pattern: ca_path = "/etc/icinga2-pki/gelf/ca.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["gelf.conf"]
+          pattern: cert_path = "/etc/icinga2-pki/gelf/cert.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["gelf.conf"]
+          pattern: key_path = "/etc/icinga2-pki/gelf/cert.key"
+        documentIndex: 1
+
+  - it: Icinga2 configmap gelf tls failure
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          gelf:
+            enabled: true
+            secretName: icinga-gelf
+            enable_tls: true
+            caSecretKey: gelf-gelf-key
+    release:
+      name: my-icinga
+    asserts:
+      - failedTemplate:
+          errorMessage: "GELF cert secrets not set. Set .Values.features.gelf.secretName, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey"
+
+  - it: Icinga2 configmap icingadb test without password
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          icingadb:
+            enabled: true
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - matchRegex:
+          path: data["icingadb.conf"]
+          pattern: password = getenv\("ICINGA_ICINGADB_PASSWORD"\)
+        documentIndex: 1
+        not: true
+
+  - it: Icinga2 configmap icingadb test with password
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          icingadb:
+            enabled: true
+            secretName: icinga-icingadb-secret
+            password:
+              secretKey: password-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - matchRegex:
+          path: data["icingadb.conf"]
+          pattern: password = getenv\("ICINGA_ICINGADB_PASSWORD"\)
+        documentIndex: 1
+
+  - it: Icinga2 configmap icingadb tls test
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          icingadb:
+            enabled: true
+            secretName: icinga-icingadb
+            enable_tls: true
+            caSecretKey: icingadb-ca-key
+            certSecretKey: icingadb-cert-key
+            keySecretKey: icingadb-key-key
+            crlSecretKey: icingadb-crl-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - matchRegex:
+          path: data["icingadb.conf"]
+          pattern: ca_path = "/etc/icinga2-pki/icingadb/ca.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["icingadb.conf"]
+          pattern: cert_path = "/etc/icinga2-pki/icingadb/cert.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["icingadb.conf"]
+          pattern: key_path = "/etc/icinga2-pki/icingadb/cert.key"
+        documentIndex: 1
+      - matchRegex:
+          path: data["icingadb.conf"]
+          pattern: crl_path = "/etc/icinga2-pki/icingadb/crl.pem"
+        documentIndex: 1
+
+  - it: Icinga2 configmap icingadb tls failure
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          icingadb:
+            enabled: true
+            secretName: icinga-icingadb
+            enable_tls: true
+            caSecretKey: icingadb-ca-key
+            keySecretKey: icingadb-key-key
+            crlSecretKey: icingadb-crl-key
+    release:
+      name: my-icinga
+    asserts:
+      - failedTemplate:
+          errorMessage: "icingadb cert secrets not set. Set .Values.features.icingadb.secretName, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey"
+
+  - it: Icinga2 configmap influxdb2 ssl test
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          influxdb2:
+            enabled: true
+            secretName: icinga-influxdb2
+            ssl_enable: true
+            caSecretKey: influxdb2-ca-key
+            certSecretKey: influxdb2-cert-key
+            keySecretKey: influxdb2-key-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - matchRegex:
+          path: data["influxdb2.conf"]
+          pattern: ssl_ca_cert = "/etc/icinga2-pki/influxdb2/ca.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["influxdb2.conf"]
+          pattern: ssl_cert = "/etc/icinga2-pki/influxdb2/cert.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["influxdb2.conf"]
+          pattern: ssl_key = "/etc/icinga2-pki/influxdb2/cert.key"
+        documentIndex: 1
+
+  - it: Icinga2 configmap influxdb2 tls failure
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          influxdb2:
+            enabled: true
+            secretName: icinga-influxdb2
+            ssl_enable: true
+            caSecretKey: influxdb2-ca-key
+            keySecretKey: influxdb2-key-key
+            crlSecretKey: influxdb2-crl-key
+    release:
+      name: my-icinga
+    asserts:
+      - failedTemplate:
+          errorMessage: "influxdb2 cert secrets not set. Set .Values.features.influxdb2.secretName, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey"
+
+  - it: Icinga2 configmap influxdb ssl test
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          influxdb:
+            enabled: true
+            secretName: icinga-influxdb
+            ssl_enable: true
+            caSecretKey: influxdb-ca-key
+            certSecretKey: influxdb-cert-key
+            keySecretKey: influxdb-key-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: ConfigMap
+          apiVersion: v1
+      - matchRegex:
+          path: data["influxdb.conf"]
+          pattern: ssl_ca_cert = "/etc/icinga2-pki/influxdb/ca.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["influxdb.conf"]
+          pattern: ssl_cert = "/etc/icinga2-pki/influxdb/cert.crt"
+        documentIndex: 1
+      - matchRegex:
+          path: data["influxdb.conf"]
+          pattern: ssl_key = "/etc/icinga2-pki/influxdb/cert.key"
+        documentIndex: 1
+
+  - it: Icinga2 configmap influxdb tls failure
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        features:
+          influxdb:
+            enabled: true
+            secretName: icinga-influxdb
+            ssl_enable: true
+            caSecretKey: influxdb-ca-key
+            keySecretKey: influxdb-key-key
+            crlSecretKey: influxdb-crl-key
+    release:
+      name: my-icinga
+    asserts:
+      - failedTemplate:
+          errorMessage: "influxdb cert secrets not set. Set .Values.features.influxdb.secretName, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey"
+
   - it: Icinga2 configmap influxdb2 test
     values:
       - required_values.yaml

--- a/charts/icinga-stack/tests/icinga2_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/icinga2_statefulset_test.yaml
@@ -282,6 +282,232 @@ tests:
                 name: "icinga-elasticsearch"
                 key: "elastic-password"
 
+  - it: deploys an Icinga2 StatefulSet with elasticsearch secrets with tls
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        config:
+          ticket_salt:
+            value: "insecuresalt"
+        features:
+          elasticsearch:
+            enabled: true
+            secretName: icinga-elasticsearch
+            username:
+              secretKey: elastic-username
+            password:
+              secretKey: elastic-password
+            enable_tls: true
+            caSecretKey: elastic-ca-key
+            certSecretKey: elastic-cert-key
+            keySecretKey: elastic-key-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: StatefulSet
+          apiVersion: apps/v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga2
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+          any: true
+      - isNull:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ICINGA_ELASTICSEARCH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: "icinga-elasticsearch"
+                key: "elastic-username"
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: ICINGA_ELASTICSEARCH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "icinga-elasticsearch"
+                key: "elastic-password"
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            mountPath: "/etc/icinga2-pki/elastic"
+            name: elastic-certs
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: elastic-certs
+            secret:
+              secretName: "icinga-elasticsearch"
+              items:
+              - key: "elastic-ca-key"
+                path: "ca.crt"
+              - key: "elastic-cert-key"
+                path: "cert.crt"
+              - key: "elastic-key-key"
+                path: "cert.key"
+
+  - it: deploys an Icinga2 StatefulSet with gelf secrets with tls
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        config:
+          ticket_salt:
+            value: "insecuresalt"
+        features:
+          gelf:
+            enabled: true
+            secretName: icinga-gelf
+            enable_tls: true
+            caSecretKey: gelf-ca-key
+            certSecretKey: gelf-cert-key
+            keySecretKey: gelf-key-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: StatefulSet
+          apiVersion: apps/v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga2
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+          any: true
+      - isNull:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            mountPath: "/etc/icinga2-pki/gelf"
+            name: gelf-certs
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: gelf-certs
+            secret:
+              secretName: "icinga-gelf"
+              items:
+              - key: "gelf-ca-key"
+                path: "ca.crt"
+              - key: "gelf-cert-key"
+                path: "cert.crt"
+              - key: "gelf-key-key"
+                path: "cert.key"
+
+  - it: deploys an Icinga2 StatefulSet with icingadb password value
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        config:
+          ticket_salt:
+            value: "insecuresalt"
+        features:
+          icingadb:
+            enabled: true
+            password:
+              value: icingadb-password
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: StatefulSet
+          apiVersion: apps/v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga2
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+          any: true
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: ICINGA_ICINGADB_PASSWORD
+            value: "icingadb-password"
+
+  - it: deploys an Icinga2 StatefulSet with icingadb secrets with tls
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        config:
+          ticket_salt:
+            value: "insecuresalt"
+        features:
+          icingadb:
+            enabled: true
+            secretName: icinga-icingadb
+            enable_tls: true
+            password:
+              secretKey: icingadb-password
+            caSecretKey: icingadb-ca-key
+            certSecretKey: icingadb-cert-key
+            keySecretKey: icingadb-key-key
+            crlSecretKey: icingadb-crl-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: StatefulSet
+          apiVersion: apps/v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga2
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+          any: true
+      - isNull:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            mountPath: "/etc/icinga2-pki/icingadb"
+            name: icingadb-certs
+            readOnly: true
+      - contains:
+          path: spec.template.spec.initContainers[0].env
+          content:
+            name: ICINGA_ICINGADB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "icinga-icingadb"
+                key: "icingadb-password"
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: icingadb-certs
+            secret:
+              secretName: "icinga-icingadb"
+              items:
+              - key: "icingadb-ca-key"
+                path: "ca.crt"
+              - key: "icingadb-cert-key"
+                path: "cert.crt"
+              - key: "icingadb-key-key"
+                path: "cert.key"
+              - key: "icingadb-crl-key"
+                path: "crl.pem"
+
   - it: deploys an Icinga2 StatefulSet with influxdb2 values
     values:
       - required_values.yaml
@@ -329,8 +555,8 @@ tests:
         features:
           influxdb2:
             enabled: true
+            secretName: icinga-influxdb2
             auth_token:
-              secretName: icinga-influxdb2
               secretKey: authToken
     release:
       name: my-icinga
@@ -358,6 +584,70 @@ tests:
                 name: "icinga-influxdb2"
                 key: "authToken"
 
+  - it: deploys an Icinga2 StatefulSet with influxdb2 secrets with ssl
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        config:
+          ticket_salt:
+            value: "insecuresalt"
+        features:
+          influxdb2:
+            enabled: true
+            secretName: icinga-influxdb2-secret
+            auth_token:
+              secretKey: authToken
+            ssl_enable: true
+            caSecretKey: influxdb2-ca-key
+            certSecretKey: influxdb2-cert-key
+            keySecretKey: influxdb2-key-key
+            
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: StatefulSet
+          apiVersion: apps/v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga2
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+          any: true
+      - isNull:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ICINGA_INFLUXDB2_AUTH_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: "icinga-influxdb2-secret"
+                key: "authToken"
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            mountPath: "/etc/icinga2-pki/influxdb2"
+            name: influxdb2-certs
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: influxdb2-certs
+            secret:
+              secretName: "icinga-influxdb2-secret"
+              items:
+              - key: "influxdb2-ca-key"
+                path: "ca.crt"
+              - key: "influxdb2-cert-key"
+                path: "cert.crt"
+              - key: "influxdb2-key-key"
+                path: "cert.key"
+
   - it: failed deployment of an Icinga2 StatefulSet with influxdb2 due to missing auth_token
     values:
       - required_values.yaml
@@ -373,7 +663,7 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "Icinga InfluxDB2 auth_token not set. Either set .Values.features.influxdb2.auth_token.value or .Values.features.influxdb2.auth_token.secretName and .Values.features.influxdb2.auth_token.secretKey"
+          errorMessage: "Icinga InfluxDB2 auth_token not set. Either set .Values.features.influxdb2.auth_token.value or .Values.features.influxdb2.secretName and .Values.features.influxdb2.auth_token.secretKey"
 
   - it: deploys an Icinga2 StatefulSet with influxdb values
     values:
@@ -503,3 +793,97 @@ tests:
               secretKeyRef:
                 name: "icinga-influxdb"
                 key: "basic-auth-password"
+            
+  - it: deploys an Icinga2 StatefulSet with influxdb secrets with ssl
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        config:
+          ticket_salt:
+            value: "insecuresalt"
+        features:
+          influxdb:
+            enabled: true
+            secretName: icinga-influxdb-secret
+            username:
+              secretKey: username
+            password:
+              secretKey: password
+            basic_auth:
+              username:
+                secretKey: basic-auth-username
+              password:
+                secretKey: basic-auth-password
+            ssl_enable: true
+            caSecretKey: influxdb-ca-key
+            certSecretKey: influxdb-cert-key
+            keySecretKey: influxdb-key-key
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: StatefulSet
+          apiVersion: apps/v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga2
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: data
+            emptyDir: {}
+          any: true
+      - isNull:
+          path: spec.volumeClaimTemplates
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ICINGA_INFLUXDB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: "icinga-influxdb-secret"
+                key: "username"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ICINGA_INFLUXDB_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "icinga-influxdb-secret"
+                key: "password"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ICINGA_INFLUXDB_BASIC_AUTH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: "icinga-influxdb-secret"
+                key: "basic-auth-username"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ICINGA_INFLUXDB_BASIC_AUTH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "icinga-influxdb-secret"
+                key: "basic-auth-password"
+      - contains:
+          path: spec.template.spec.initContainers[0].volumeMounts
+          content:
+            mountPath: "/etc/icinga2-pki/influxdb"
+            name: influxdb-certs
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: influxdb-certs
+            secret:
+              secretName: "icinga-influxdb-secret"
+              items:
+              - key: "influxdb-ca-key"
+                path: "ca.crt"
+              - key: "influxdb-cert-key"
+                path: "cert.crt"
+              - key: "influxdb-key-key"
+                path: "cert.key"

--- a/charts/icinga-stack/tests/icinga2_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/icinga2_statefulset_test.yaml
@@ -129,7 +129,7 @@ tests:
       global:
         api:
           users:
-            secretName: api-users
+            credSecret: api-users
             director:
               password:
             icingaweb:
@@ -139,7 +139,7 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "director api user password not set. Set either .Values.global.api.users.director.password.value or .Values.global.api.users.secretName and .Values.global.api.users.director.password.secretKey"
+          errorMessage: "director api user password not set. Set either .Values.global.api.users.director.password.value or .Values.global.api.users.credSecret and .Values.global.api.users.director.password.secretKey"
   
   - it: deploys an Icinga2 StatefulSet with persistence
     values:
@@ -187,7 +187,7 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "Icinga TicketSalt not set. Either set .Values.config.ticket_salt.value or .Values.config.ticket_salt.secretName and .Values.config.ticket_salt.secretKey"
+          errorMessage: "Icinga TicketSalt not set. Either set .Values.config.ticket_salt.value or .Values.config.ticket_salt.credSecret and .Values.config.ticket_salt.secretKey"
 
   - it: deploys an Icinga2 StatefulSet with elasticsearch values
     values:
@@ -243,7 +243,7 @@ tests:
         features:
           elasticsearch:
             enabled: true
-            secretName: icinga-elasticsearch
+            credSecret: icinga-elasticsearch
             username:
               secretKey: elastic-username
             password:
@@ -293,7 +293,8 @@ tests:
         features:
           elasticsearch:
             enabled: true
-            secretName: icinga-elasticsearch
+            credSecret: icinga-elasticsearch-creds
+            tlsSecret: icinga-elasticsearch-certs
             username:
               secretKey: elastic-username
             password:
@@ -325,7 +326,7 @@ tests:
             name: ICINGA_ELASTICSEARCH_USERNAME
             valueFrom:
               secretKeyRef:
-                name: "icinga-elasticsearch"
+                name: "icinga-elasticsearch-creds"
                 key: "elastic-username"
       - contains:
           path: spec.template.spec.initContainers[0].env
@@ -333,7 +334,7 @@ tests:
             name: ICINGA_ELASTICSEARCH_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: "icinga-elasticsearch"
+                name: "icinga-elasticsearch-creds"
                 key: "elastic-password"
       - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
@@ -346,7 +347,7 @@ tests:
           content:
             name: elastic-certs
             secret:
-              secretName: "icinga-elasticsearch"
+              secretName: "icinga-elasticsearch-certs"
               items:
               - key: "elastic-ca-key"
                 path: "ca.crt"
@@ -366,7 +367,7 @@ tests:
         features:
           gelf:
             enabled: true
-            secretName: icinga-gelf
+            tlsSecret: icinga-gelf
             enable_tls: true
             caSecretKey: gelf-ca-key
             certSecretKey: gelf-cert-key
@@ -453,7 +454,8 @@ tests:
         features:
           icingadb:
             enabled: true
-            secretName: icinga-icingadb
+            credSecret: icinga-icingadb-creds
+            tlsSecret: icinga-icingadb-certs
             enable_tls: true
             password:
               secretKey: icingadb-password
@@ -490,14 +492,14 @@ tests:
             name: ICINGA_ICINGADB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: "icinga-icingadb"
+                name: "icinga-icingadb-creds"
                 key: "icingadb-password"
       - contains:
           path: spec.template.spec.volumes
           content:
             name: icingadb-certs
             secret:
-              secretName: "icinga-icingadb"
+              secretName: "icinga-icingadb-certs"
               items:
               - key: "icingadb-ca-key"
                 path: "ca.crt"
@@ -555,7 +557,7 @@ tests:
         features:
           influxdb2:
             enabled: true
-            secretName: icinga-influxdb2
+            credSecret: icinga-influxdb2
             auth_token:
               secretKey: authToken
     release:
@@ -595,7 +597,8 @@ tests:
         features:
           influxdb2:
             enabled: true
-            secretName: icinga-influxdb2-secret
+            credSecret: icinga-influxdb2-creds
+            tlsSecret: icinga-influxdb2-certs
             auth_token:
               secretKey: authToken
             ssl_enable: true
@@ -626,7 +629,7 @@ tests:
             name: ICINGA_INFLUXDB2_AUTH_TOKEN
             valueFrom:
               secretKeyRef:
-                name: "icinga-influxdb2-secret"
+                name: "icinga-influxdb2-creds"
                 key: "authToken"
       - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
@@ -639,7 +642,7 @@ tests:
           content:
             name: influxdb2-certs
             secret:
-              secretName: "icinga-influxdb2-secret"
+              secretName: "icinga-influxdb2-certs"
               items:
               - key: "influxdb2-ca-key"
                 path: "ca.crt"
@@ -663,7 +666,7 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "Icinga InfluxDB2 auth_token not set. Either set .Values.features.influxdb2.auth_token.value or .Values.features.influxdb2.secretName and .Values.features.influxdb2.auth_token.secretKey"
+          errorMessage: "Icinga InfluxDB2 auth_token not set. Either set .Values.features.influxdb2.auth_token.value or .Values.features.influxdb2.credSecret and .Values.features.influxdb2.auth_token.secretKey"
 
   - it: deploys an Icinga2 StatefulSet with influxdb values
     values:
@@ -734,7 +737,7 @@ tests:
         features:
           influxdb:
             enabled: true
-            secretName: icinga-influxdb
+            credSecret: icinga-influxdb
             username:
               secretKey: username
             password:
@@ -805,7 +808,8 @@ tests:
         features:
           influxdb:
             enabled: true
-            secretName: icinga-influxdb-secret
+            credSecret: icinga-influxdb-secret-creds
+            tlsSecret: icinga-influxdb-secret-certs
             username:
               secretKey: username
             password:
@@ -842,7 +846,7 @@ tests:
             name: ICINGA_INFLUXDB_USERNAME
             valueFrom:
               secretKeyRef:
-                name: "icinga-influxdb-secret"
+                name: "icinga-influxdb-secret-creds"
                 key: "username"
       - contains:
           path: spec.template.spec.containers[0].env
@@ -850,7 +854,7 @@ tests:
             name: ICINGA_INFLUXDB_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: "icinga-influxdb-secret"
+                name: "icinga-influxdb-secret-creds"
                 key: "password"
       - contains:
           path: spec.template.spec.containers[0].env
@@ -858,7 +862,7 @@ tests:
             name: ICINGA_INFLUXDB_BASIC_AUTH_USERNAME
             valueFrom:
               secretKeyRef:
-                name: "icinga-influxdb-secret"
+                name: "icinga-influxdb-secret-creds"
                 key: "basic-auth-username"
       - contains:
           path: spec.template.spec.containers[0].env
@@ -866,7 +870,7 @@ tests:
             name: ICINGA_INFLUXDB_BASIC_AUTH_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: "icinga-influxdb-secret"
+                name: "icinga-influxdb-secret-creds"
                 key: "basic-auth-password"
       - contains:
           path: spec.template.spec.initContainers[0].volumeMounts
@@ -879,7 +883,7 @@ tests:
           content:
             name: influxdb-certs
             secret:
-              secretName: "icinga-influxdb-secret"
+              secretName: "icinga-influxdb-secret-certs"
               items:
               - key: "influxdb-ca-key"
                 path: "ca.crt"

--- a/charts/icinga-stack/tests/icingaweb2_deployment_test.yaml
+++ b/charts/icinga-stack/tests/icingaweb2_deployment_test.yaml
@@ -155,7 +155,7 @@ tests:
           graphite:
             enabled: true
             graphite:
-              secretName: graphite-secret
+              credSecret: graphite-secret
               user:
                 secretKey: graphite-user
               password:
@@ -193,7 +193,7 @@ tests:
       global:
         api:
           users:
-            secretName: api-users
+            credSecret: api-users
             director:
               password:
             icingaweb:
@@ -203,4 +203,4 @@ tests:
       name: my-icinga
     asserts:
       - failedTemplate:
-          errorMessage: "director api user password not set. Set either .Values.global.api.users.director.password.value or .Values.global.api.users.secretName and .Values.global.api.users.director.password.secretKey"
+          errorMessage: "director api user password not set. Set either .Values.global.api.users.director.password.value or .Values.global.api.users.credSecret and .Values.global.api.users.director.password.secretKey"

--- a/charts/icinga-stack/tests/required_values_secrets.yaml
+++ b/charts/icinga-stack/tests/required_values_secrets.yaml
@@ -1,19 +1,19 @@
 icinga2:
   config:
     ticket_salt:
-      secretName: icinga2-secret
+      credSecret: icinga2-secret
       secretKey: ticket_salt
 
 icingaweb2:
   auth:
     admin_password:
-      secretName: icingaweb2-secret
+      credSecret: icingaweb2-secret
       secretKey: admin_password
 
 global:
   api:
     users:
-      secretName: api-users
+      credSecret: api-users
       director:
         password:
           secretKey: director-password
@@ -22,19 +22,19 @@ global:
           secretKey: icingaweb-password
   databases:
     director:
-      secretName: database-director
+      credSecret: database-director
       username:
         secretKey: username
       password:
         secretKey: password
     icingaweb2:
-      secretName: database-icingaweb2
+      credSecret: database-icingaweb2
       username:
         secretKey: username
       password:
         secretKey: password
     icingadb:
-      secretName: database-icingadb
+      credSecret: database-icingadb
       username:
         secretKey: username
       password:

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -33,7 +33,7 @@ icinga2:
     zone_name: master
     ticket_salt:
       value:  # Add random (long!) string here
-      secretName: # Or use existing secret
+      credSecret: # Or use existing secret
       secretKey:
     disable_confd: true
 
@@ -86,7 +86,8 @@ icinga2:
       # enable_send_perfdata: false
       # flush_threshold: 1024
       # flush_interval: 10s
-      # secretName: icinga-elasticsearch-secret # used for username, password and certs
+      # credSecret: # used for credentials
+      # tlsSecret: # used for certificates
       # username: elastic
       # password: password
       # enable_tls: false
@@ -104,7 +105,7 @@ icinga2:
       # enable_send_perfdata: false
       # enable_tls: false
       # insecure_noverify: false
-      # secretName: # used for certs
+      # tlsSecret: # used for certificates
       # caSecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/ca.crt
       # certSecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/cert.crt
       # keySecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/cert.key
@@ -122,7 +123,8 @@ icinga2:
     # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#icingadb
     icingadb:
       enabled: true
-      # secretName: # used for password and certs
+      # credSecret: # used for credentials
+      # tlsSecret: # used for certificates
       # password: 
       #   value: password # Specify password
       #   secretKey: password # Or use existing secret
@@ -143,7 +145,8 @@ icinga2:
       # port: 8086
       # organization: monitoring
       # bucket: icinga2
-      # secretName: secretName # Used for auth_token and certs
+      # credSecret: # used for credentials
+      # tlsSecret: # used for certificates
       # auth_token: securitytoken
       # ssl_enable: false
       # ssl_insecure_noverify: false
@@ -176,7 +179,8 @@ icinga2:
       # host: influx
       # port: 8086
       # database: icinga2
-      # secretName: # existing secret used for influxdb credentials and basic_auth credentials
+      # credSecret: # existing secret used for influxdb credentials and basic_auth credentials
+      # tlsSecret: # used for certificates
       # username:
       #   value: # Specify username
       #   secretKey: # Or use existing secret
@@ -392,7 +396,7 @@ icingaweb2:
     admin_user: icingaweb
     admin_password:
       value: # Add a password here
-      secretName:
+      credSecret:
       secretKey:
 
   modules:
@@ -420,7 +424,7 @@ icingaweb2:
       enabled: false
       graphite:
         url: graphite.example.com
-        secretName:
+        credSecret:
         user:
           value:
           secretKey:
@@ -493,7 +497,7 @@ global:
     # host:  # only needed if Icinga2 runs out of cluster
     port: 5665
     users:
-      secretName: # Existing secret for director and icingaweb password
+      credSecret: # Existing secret for director and icingaweb password
       director:
         password:
           value: # Add a password here
@@ -511,7 +515,7 @@ global:
   databases:
     director:
       database: directordb
-      secretName: # Existing secret name for username and password
+      credSecret: # Existing secret name for username and password
       username:
         value: # Set username
         secretKey: # Or specify secret key
@@ -533,7 +537,7 @@ global:
 
     icingadb:
       database: icingadb
-      secretName: # Existing secret name for username and password
+      credSecret: # Existing secret name for username and password
       username:
         value: # Set username
         secretKey: # Or specify secret key
@@ -555,7 +559,7 @@ global:
 
     icingaweb2:
       database: icingaweb2db
-      secretName: # Existing secret name for username and password
+      credSecret: # Existing secret name for username and password
       username: 
         value: # Set username
         secretKey: # Or specify secret key
@@ -577,7 +581,7 @@ global:
 
     x509:
       database: x509db
-      secretName: # Existing secret name for username and password
+      credSecret: # Existing secret name for username and password
       username: 
         value: # Set username
         secretKey: # Or specify secret key

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -86,13 +86,14 @@ icinga2:
       # enable_send_perfdata: false
       # flush_threshold: 1024
       # flush_interval: 10s
+      # secretName: icinga-elasticsearch-secret # used for username, password and certs
       # username: elastic
       # password: password
       # enable_tls: false
       # insecure_noverify: false
-      # ca_path: /etc/icinga2/pki/elastic-ca.crt
-      # cert_path: /etc/icinga2/pki/elastic-cert.crt
-      # key_path: /etc/icinga2/pki/elastic-cert.key
+      # caSecretKey: # Secret key to mount at /etc/icinga2-pki/elastic-ca.crt
+      # certSecretKey: # Secret key to mount at /etc/icinga2-pki/elastic-cert.crt
+      # keySecretKey: # Secret key to mount at /etc/icinga2-pki/elastic-cert.key
 
     # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#gelfwriter
     gelf:
@@ -103,9 +104,10 @@ icinga2:
       # enable_send_perfdata: false
       # enable_tls: false
       # insecure_noverify: false
-      # ca_path: /etc/icinga2/pki/gelf-ca.crt
-      # cert_path: /etc/icinga2/pki/gelf-cert.crt
-      # key_path: /etc/icinga2/pki/gelf-cert.key
+      # secretName: # used for certs
+      # caSecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/ca.crt
+      # certSecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/cert.crt
+      # keySecretKey: # Secret key to mount at /etc/icinga2-pki/gelf/cert.key
 
     # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#graphitewriter
     graphite:
@@ -120,12 +122,15 @@ icinga2:
     # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#icingadb
     icingadb:
       enabled: true
-      # password:
+      # secretName: # used for password and certs
+      # password: 
+      #   value: password # Specify password
+      #   secretKey: password # Or use existing secret
       # enable_tls: false
-      # cert_path: /etc/icinga2/pki/icingadb-cert.crt
-      # key_path: /etc/icinga2/pki/icingadb-cert.key
-      # ca_path: /etc/icinga2/pki/icingadb-ca.crt
-      # crl_path: /etc/icinga2/pki/icingadb-crl.pem
+      # certSecretKey: # Secret key to mount at /etc/icinga2-pki/icingadb/cert.crt
+      # keySecretKey: # Secret key to mount at /etc/icinga2-pki/icingadb/cert.key
+      # caSecretKey: # Secret key to mount at /etc/icinga2-pki/icingadb/ca.crt
+      # crlSecretKey: # Secret key to mount at /etc/icinga2/pki/icingadb/crl.pem
       # cipher_list: ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:AES256-GCM-SHA384:AES128-GCM-SHA256
       # tls_protocolmin: TLSv1.2
       # insecure_noverify: false
@@ -138,12 +143,13 @@ icinga2:
       # port: 8086
       # organization: monitoring
       # bucket: icinga2
+      # secretName: secretName # Used for auth_token and certs
       # auth_token: securitytoken
       # ssl_enable: false
       # ssl_insecure_noverify: false
-      # ssl_ca_cert: /etc/icinga2/pki/influxdb2-ca.crt
-      # ssl_cert: /etc/icinga2/pki/influxdb2-cert.crt
-      # ssl_key: /etc/icinga2/pki/influxdb2-cert.key
+      # caSecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb2/ca.crt
+      # certSecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb2/cert.crt
+      # keySecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb2/cert.key
       # enable_send_thresholds: false
       # enable_send_metadata: false
       # flush_threshold: 1024
@@ -170,16 +176,25 @@ icinga2:
       # host: influx
       # port: 8086
       # database: icinga2
-      # username: none
-      # password: password
+      # secretName: # existing secret used for influxdb credentials and basic_auth credentials
+      # username:
+      #   value: # Specify username
+      #   secretKey: # Or use existing secret
+      # password:
+      #   value: # Specify password
+      #   secretKey: # Or use existing secret
       # basic_auth:
-      #   username: icinga2
-      #   password: icinga2
+      #   username:
+      #     value: # Specify username
+      #     secretKey: # Or use existing secret
+      #   password:
+      #     value: # Specify password
+      #     secretKey: # Or use existing secret
       # ssl_enable: false
       # ssl_insecure_noverify: false
-      # ssl_ca_cert: /etc/icinga2/pki/influxdb-ca.crt
-      # ssl_cert: /etc/icinga2/pki/influxdb-cert.crt
-      # ssl_key: /etc/icinga2/pki/influxdb-cert.key
+      # caSecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb/ca.crt
+      # certSecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb/cert.crt
+      # keySecretKey: # Secret key to mount at /etc/icinga2-pki/influxdb/cert.key
       # enable_send_thresholds: false
       # enable_send_metadata: false
       # flush_threshold: 1024
@@ -198,6 +213,7 @@ icinga2:
             hostname = "$host.name$"
             service = "$service.name$"
           }
+        }
 
     # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#filelogger
     mainlog:


### PR DESCRIPTION
This PR resolves issue #21.

Certificates are projected in containers using kubernets secrets and are mounted in `/etc/icinga2-pki/<feature>/` directory. On enabling TLS/SSL in feature all certificates are required (i.e. ca, cert and key).

Sample configuration for elasticsearch:
```
icinga2:
  features:
    elasticsearch:
      enabled: true
      secretName: icinga-elasticsearch-secret
      enable_tls: true
      caSecretKey: ca
      certSecretKey: cert
      keySecretKey: key
```

Besides resolving issue #21 there are some more related changes:
- I've renamed `.Values.global.redis.password` to `.Values.features.icingadb.password.value` and enabled configuration via value/secret (I've overloked this sensible value in PR #17)
- default value for `.Values.features.influxdb.service_template` is updated (closing `}`) was missing