### PR TITLE
icinga-stack: extraEnvVars value for icinga2/icingadb

### DIFF
--- a/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
+++ b/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
@@ -34,7 +34,9 @@ spec:
             - name: ICINGA_DISABLE_CONFD
               value: {{ .Values.config.disable_confd | int | quote }}
             {{- include "icinga2.envSecrets" . | nindent 12 }}
+            {{- if .Values.extraEnvVars }}
             {{- toYaml .Values.extraEnvVars | nindent 12 }}
+            {{- end }}
           ports:
             - name: api
               containerPort: {{ .Values.service.port }}

--- a/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
+++ b/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
@@ -34,6 +34,7 @@ spec:
             - name: ICINGA_DISABLE_CONFD
               value: {{ .Values.config.disable_confd | int | quote }}
             {{- include "icinga2.envSecrets" . | nindent 12 }}
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
           ports:
             - name: api
               containerPort: {{ .Values.service.port }}

--- a/charts/icinga-stack/charts/icinga2/values.yaml
+++ b/charts/icinga-stack/charts/icinga2/values.yaml
@@ -310,3 +310,5 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+
+extraEnvVars: []

--- a/charts/icinga-stack/charts/icingadb/templates/deployment.yaml
+++ b/charts/icinga-stack/charts/icingadb/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
               {{- end }}
             - name: ICINGADB_DATABASE_DATABASE
               value: {{ .Values.global.databases.icingadb.database | default "mysql" | quote }}
+            {{- if .Values.extraEnvVars }}
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/icinga-stack/charts/icingadb/values.yaml
+++ b/charts/icinga-stack/charts/icingadb/values.yaml
@@ -50,3 +50,5 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+
+extraEnvVars: []

--- a/charts/icinga-stack/tests/icinga2_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/icinga2_statefulset_test.yaml
@@ -891,3 +891,30 @@ tests:
                 path: "cert.crt"
               - key: "influxdb-key-key"
                 path: "cert.key"
+
+  - it: deploys an Icinga2 StatefulSet with extra environment variables
+    values:
+      - required_values.yaml
+    set:
+      icinga2:
+        config:
+          ticket_salt:
+            value: "insecuresalt"
+        extraEnvVars:
+          - name: ENV_VAR_1
+            value: env_var_1
+          - name: ENV_VAR_2
+            value: env_var_2
+    release:
+      name: my-icinga
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENV_VAR_1
+            value: env_var_1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENV_VAR_2
+            value: env_var_2

--- a/charts/icinga-stack/tests/icingadb_deployment_test.yaml
+++ b/charts/icinga-stack/tests/icingadb_deployment_test.yaml
@@ -66,3 +66,27 @@ tests:
               secretKeyRef:
                 name: database-icingadb
                 key: password
+
+  - it: deploys an IcingaDB deployment with extra environment variables
+    values:
+      - required_values.yaml
+    set:
+      icingadb:
+        extraEnvVars:
+          - name: ENV_VAR_1
+            value: env_var_1
+          - name: ENV_VAR_2
+            value: env_var_2
+    release:
+      name: my-icinga
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENV_VAR_1
+            value: env_var_1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENV_VAR_2
+            value: env_var_2

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -358,6 +358,8 @@ icingadb:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+  extraEnvVars: []
+
 icingaweb2:
   enabled: true
 

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -492,6 +492,8 @@ icingaweb2:
     # runAsNonRoot: true
     # runAsUser: 1000
 
+  extraEnvVars: []
+
 global:
   api:
     # host:  # only needed if Icinga2 runs out of cluster


### PR DESCRIPTION
Value to add extra environment variables in icinga2 container, useful to fill variables like PGHOST, PGPORT, PGDATABASE, PGUSER, PGPASSWORD, etc.