### PR TITLE
Add `Icinga Kubernetes`

### DIFF
--- a/.github/workflows/lint_test_charts.yaml
+++ b/.github/workflows/lint_test_charts.yaml
@@ -24,4 +24,5 @@ jobs:
           run: |
             set -x
             cd charts/icinga-stack
+            helm dependency update
             helm unittest .

--- a/charts/icinga-stack/Chart.yaml
+++ b/charts/icinga-stack/Chart.yaml
@@ -1,3 +1,8 @@
+dependencies:
+  - name: common
+    version: 2.x.x
+    repository: oci://registry-1.docker.io/bitnamicharts
+
 apiVersion: v2
 name: icinga-stack
 description: Icinga is a monitoring system which checks the availability of your network resources, notifies users of outages, and generates performance data for reporting.

--- a/charts/icinga-stack/README.md
+++ b/charts/icinga-stack/README.md
@@ -45,6 +45,8 @@ helm install <release-name> \
   --set global.databases.icingaweb2.password.value=CHANGE-ME \
   --set global.databases.icingadb.username.value=CHANGE-ME \
   --set global.databases.icingadb.password.value=CHANGE-ME \
+  --set global.databases.kubernetes.username.value=CHANGE-ME \
+  --set global.databases.kubernetes.password.value=CHANGE-ME \
 icinga/icinga-stack
 ```
 

--- a/charts/icinga-stack/charts/icinga-kubernetes/Chart.yaml
+++ b/charts/icinga-stack/charts/icinga-kubernetes/Chart.yaml
@@ -1,0 +1,16 @@
+dependencies:
+  - name: common
+    version: 2.x.x
+    repository: oci://registry-1.docker.io/bitnamicharts
+
+apiVersion: v2
+name: icinga-kubernetes
+description: Icinga Kubernetes
+maintainers:
+  - name: Icinga GmbH
+    email: info@icinga.com
+    url: https://icinga.com
+
+type: application
+version: 0.1.0
+appVersion: "edge"

--- a/charts/icinga-stack/charts/icinga-kubernetes/templates/_config.tpl
+++ b/charts/icinga-stack/charts/icinga-kubernetes/templates/_config.tpl
@@ -1,0 +1,27 @@
+{{/*
+ Create the config
+ */}}
+{{- define "icinga-kubernetes.config" -}}
+# This is the configuration file for Icinga Kubernetes.
+
+# Connection configuration for the database to which Icinga Kubernetes synchronizes data.
+# This is also the database used in Icinga Kubernetes Web to view and work with the data.
+database:
+    # Database type. Only 'mysql' is supported yet which is the default.
+    #  type: mysql
+
+    # Database host or absolute Unix socket path.
+    host: {{ if .Values.global.databases.kubernetes.enabled }} {{ .Release.Name }}-kubernetes-database {{ else }} {{ .Values.global.databases.kubernetes.host | quote }} {{ end }}
+
+    # Database port. By default, the MySQL port.
+    port: {{ .Values.global.databases.kubernetes.port | default 3306 }}
+
+    # Database name.
+    database: kubernetes
+
+    # Database user.
+    user: {{ .Values.global.databases.kubernetes.username.value }}
+
+    # Database password.
+    password: {{ .Values.global.databases.kubernetes.password.value }}
+{{- end -}}

--- a/charts/icinga-stack/charts/icinga-kubernetes/templates/_helpers.tpl
+++ b/charts/icinga-stack/charts/icinga-kubernetes/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+ Create the name of the service account to use
+ */}}
+{{- define "icinga-kubernetes.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{- default (include "common.names.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+    {{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ Create the name of the config map to use
+ */}}
+{{- define "icinga-kubernetes.configmapName" -}}
+{{- printf "%s-configuration" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+

--- a/charts/icinga-stack/charts/icinga-kubernetes/templates/clusterrole.yaml
+++ b/charts/icinga-stack/charts/icinga-kubernetes/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+kind: ClusterRole
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - get
+      - watch
+      - list
+{{- end }}

--- a/charts/icinga-stack/charts/icinga-kubernetes/templates/clusterrolebinding.yaml
+++ b/charts/icinga-stack/charts/icinga-kubernetes/templates/clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "common.names.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "icinga-kubernetes.serviceAccountName" . }}
+    namespace: {{ include "common.names.namespace" . | quote }}
+{{- end }}

--- a/charts/icinga-stack/charts/icinga-kubernetes/templates/configmap.yaml
+++ b/charts/icinga-stack/charts/icinga-kubernetes/templates/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "icinga-kubernetes.configmapName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  config.yml: |-
+    {{- include "icinga-kubernetes.config" . | nindent 4 }}

--- a/charts/icinga-stack/charts/icinga-kubernetes/templates/deployment.yaml
+++ b/charts/icinga-stack/charts/icinga-kubernetes/templates/deployment.yaml
@@ -1,0 +1,39 @@
+{{ if .Values.enabled -}}
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: 1
+  {{- $podLabels := include "common.tplvalues.merge" ( dict "values" ( list .Values.podLabels .Values.commonLabels ) "context" . ) }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" ( dict "customLabels" $podLabels "context" $ ) | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "common.labels.standard" ( dict "customLabels" $podLabels "context" $ ) | nindent 8 }}
+      annotations:
+        {{- if .Values.podAnnotations }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "icinga-kubernetes.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name}}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          volumeMounts:
+            - name: configuration
+              mountPath: /config.yml
+              subPath: config.yml
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: configuration
+          configMap:
+            name: {{ include "icinga-kubernetes.configmapName" . }}
+{{- end }}

--- a/charts/icinga-stack/charts/icinga-kubernetes/templates/serviceaccount.yaml
+++ b/charts/icinga-stack/charts/icinga-kubernetes/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "icinga-kubernetes.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" .Values.commonLabels "context" $ ) | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.serviceAccount.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/icinga-stack/charts/icinga-kubernetes/values.yaml
+++ b/charts/icinga-stack/charts/icinga-kubernetes/values.yaml
@@ -1,0 +1,12 @@
+enabled: true
+
+image:
+  repository: icinga/icinga-kubernetes
+  tag: edge
+  pullPolicy: Always
+
+rbac:
+  create: true
+
+serviceAccount:
+  create: true

--- a/charts/icinga-stack/charts/icingaweb2/values.yaml
+++ b/charts/icinga-stack/charts/icingaweb2/values.yaml
@@ -3,7 +3,7 @@ enabled: true
 image:
   repository: icinga/icingaweb2
   tag: 2.12.1
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 imagePullSecrets: []
 

--- a/charts/icinga-stack/charts/icingaweb2/values.yaml
+++ b/charts/icinga-stack/charts/icingaweb2/values.yaml
@@ -2,7 +2,7 @@ enabled: true
 
 image:
   repository: icinga/icingaweb2
-  tag: 2.11.4
+  tag: 2.12.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/icinga-stack/tests/global_database_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/global_database_statefulset_test.yaml
@@ -240,6 +240,31 @@ tests:
                 name: database-icingaweb2
                 key: password
 
+  # Icinga Kubernetes DB
+  - it: deploys an Icinga Kubernetes database StatefulSet using values
+    documentIndex: 8
+    values:
+      - required_values.yaml
+    release:
+      name: my-icinga
+    asserts:
+      - containsDocument:
+          kind: StatefulSet
+          apiVersion: apps/v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga-stack-kubernetes-database
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MARIADB_USER
+            value: kubernetes
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MARIADB_PASSWORD
+            value: insecurekubernetesdbpassword
+
   # Test persistence for databases
   - it: deploys a PVC for a database if persistence is enabled
     documentIndex: 0
@@ -253,6 +278,8 @@ tests:
       global.databases.icingadb.password.value: insecurepassword
       global.databases.icingaweb2.username.value: icingaweb2
       global.databases.icingaweb2.password.value: insecurepassword
+      global.databases.kubernetes.username.value: kubernetes
+      global.databases.kubernetes.password.value: insecurepassword
     release:
       name: my-icinga
     asserts:

--- a/charts/icinga-stack/tests/global_database_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/global_database_statefulset_test.yaml
@@ -2,7 +2,7 @@ suite: "[Global] Internal databases for Icinga services"
 templates:
   - internal-databases.yaml
 tests:
-  # Director DB 
+  # Director DB
   - it: deploys a Director database StatefulSet using values
     documentIndex: 0
     values:
@@ -129,7 +129,7 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "director password not set. Set either .Values.global.databases.director.password.value or .Values.global.databases.director.credSecret and .Values.global.databases.director.password.secretKey"
-  
+
   # IcingaDB DB
   - it: deploys an IcingaDB database StatefulSet using values
     documentIndex: 2
@@ -184,7 +184,7 @@ tests:
               secretKeyRef:
                 name: database-icingadb
                 key: password
-      
+
   # IcingaWeb DB
   - it: deploys an Icingaweb2 database StatefulSet using values
     documentIndex: 4
@@ -268,5 +268,3 @@ tests:
                 requests:
                   storage: 5Gi
               selector: null
-
-      

--- a/charts/icinga-stack/tests/global_database_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/global_database_statefulset_test.yaml
@@ -81,6 +81,11 @@ tests:
               secretKey: username
             password:
               secretKey: password
+          kubernetes:
+            username:
+              value: kubernetes
+            password:
+              value: insecurekubernetespassword
     release:
       name: my-icinga
     asserts:
@@ -242,7 +247,7 @@ tests:
 
   # Icinga Kubernetes DB
   - it: deploys an Icinga Kubernetes database StatefulSet using values
-    documentIndex: 8
+    documentIndex: 6
     values:
       - required_values.yaml
     release:

--- a/charts/icinga-stack/tests/icinga-kubernetes_clusterrole_test.yaml
+++ b/charts/icinga-stack/tests/icinga-kubernetes_clusterrole_test.yaml
@@ -1,0 +1,32 @@
+suite: "[Icinga Kubernetes] ClusterRole creation"
+templates:
+  - ../charts/icinga-kubernetes/templates/clusterrole.yaml
+tests:
+  - it: creates a ClusterRole if enabled
+    values:
+      - required_values.yaml
+    set:
+      icinga-kubernetes:
+        rbac:
+          create: true
+    release:
+      name: my-icinga
+      namespace: my-namespace
+    asserts:
+      - containsDocument:
+          kind: ClusterRole
+          apiVersion: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga-kubernetes
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - '*'
+            resources:
+              - '*'
+            verbs:
+              - get
+              - watch
+              - list

--- a/charts/icinga-stack/tests/icinga-kubernetes_clusterrolebinding_test.yaml
+++ b/charts/icinga-stack/tests/icinga-kubernetes_clusterrolebinding_test.yaml
@@ -1,0 +1,37 @@
+suite: "[Icinga Kubernetes] ClusterRoleBinding creation"
+templates:
+  - ../charts/icinga-kubernetes/templates/clusterrolebinding.yaml
+tests:
+  - it: creates a ClusterRoleBinding if enabled
+    values:
+      - required_values.yaml
+    set:
+      icinga-kubernetes:
+        rbac:
+          create: true
+    release:
+      name: my-icinga
+      namespace: my-namespace
+    asserts:
+      - containsDocument:
+          kind: ClusterRoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga-kubernetes
+      - equal:
+          path: roleRef.apiGroup
+          value: rbac.authorization.k8s.io
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: my-icinga-icinga-kubernetes
+      - contains:
+          path: subjects
+          content:
+            kind: ServiceAccount
+            name: my-icinga-icinga-kubernetes
+            namespace: my-namespace
+

--- a/charts/icinga-stack/tests/icinga-kubernetes_serviceaccount_test.yaml
+++ b/charts/icinga-stack/tests/icinga-kubernetes_serviceaccount_test.yaml
@@ -1,0 +1,21 @@
+suite: "[Icinga Kubernetes] ServiceAccount creation"
+templates:
+  - ../charts/icinga-kubernetes/templates/serviceaccount.yaml
+tests:
+  - it: creates a ServiceAccount if enabled
+    values:
+      - required_values.yaml
+    set:
+      icinga-kubernetes:
+        serviceAccount:
+          create: true
+    release:
+      name: my-icinga
+      namespace: my-namespace
+    asserts:
+      - containsDocument:
+          kind: ServiceAccount
+          apiVersion: v1
+      - equal:
+          path: metadata.name
+          value: my-icinga-icinga-kubernetes

--- a/charts/icinga-stack/tests/required_values.yaml
+++ b/charts/icinga-stack/tests/required_values.yaml
@@ -32,3 +32,8 @@ global:
         value: icingadb
       password:
         value: insecureicingadbpassword
+    kubernetes:
+      username:
+        value: kubernetes
+      password:
+        value: insecurekubernetesdbpassword

--- a/charts/icinga-stack/tests/required_values_secrets.yaml
+++ b/charts/icinga-stack/tests/required_values_secrets.yaml
@@ -39,3 +39,9 @@ global:
         secretKey: username
       password:
         secretKey: password
+    kubernetes:
+      credSecret: not-yet-supported
+      username:
+        secretKey: username
+      password:
+        secretKey: password

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -496,6 +496,20 @@ icingaweb2:
 
   extraEnvVars: []
 
+icinga-kubernetes:
+  enabled: true
+
+  image:
+    repository: icinga/icinga-kubernetes
+    tag: edge
+    pullPolicy: Always
+
+  rbac:
+    create: true
+
+  serviceAccount:
+    create: true
+
 global:
   api:
     # host:  # only needed if Icinga2 runs out of cluster

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -38,9 +38,9 @@ icinga2:
     disable_confd: true
 
   features:
-    # The features are configured as described in the official documentation 
+    # The features are configured as described in the official documentation
     # at https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#features
-    # Only some features are enabled by default; Some features are missing, for more information 
+    # Only some features are enabled by default; Some features are missing, for more information
     # see this project's README.md
     # `Optional` settings for each features are commented out, all other settings are required when enabling
     # a feature.
@@ -59,7 +59,7 @@ icinga2:
       # acl_allow_origin:
       #   - example.com
       #   - agent1.example.com
-      # environment: "" 
+      # environment: ""
 
     # For configuration information see https://icinga.com/docs/icinga-2/latest/doc/09-object-types/#checkercomponent
     checker:
@@ -125,7 +125,7 @@ icinga2:
       enabled: true
       # credSecret: # used for credentials
       # tlsSecret: # used for certificates
-      # password: 
+      # password:
       #   value: password # Specify password
       #   secretKey: password # Or use existing secret
       # enable_tls: false
@@ -564,7 +564,7 @@ global:
     icingaweb2:
       database: icingaweb2db
       credSecret: # Existing secret name for username and password
-      username: 
+      username:
         value: # Set username
         secretKey: # Or specify secret key
       password:
@@ -586,7 +586,7 @@ global:
     x509:
       database: x509db
       credSecret: # Existing secret name for username and password
-      username: 
+      username:
         value: # Set username
         secretKey: # Or specify secret key
       password:

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -619,6 +619,29 @@ global:
         matchLabels: {}
         matchExpressions: []
 
+    kubernetes:
+      # Note that using secrets is not yet supported for Icinga Kubernetes.
+      database: kubernetes
+      credSecret: # Existing secret name for username and password
+      username:
+        value: # Set username
+        secretKey: # Or specify secret key
+      password:
+        value: # Add a password here
+        secretKey: # Or specify secret key
+      enabled: true
+      # host: mariadb.example.com
+      # port: 3306
+      persistence:
+        enabled: false
+        size: 5Gi
+        accessMode: ReadWriteOnce
+        # storageClass: ""
+        # volumeName: ""
+        # subPath: ""
+        matchLabels: {}
+        matchExpressions: []
+
   redis:
     enabled: true
     # host: redis.example.com

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -365,7 +365,7 @@ icingaweb2:
 
   image:
     repository: icinga/icingaweb2
-    tag: 2.11.4
+    tag: 2.12.1
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -366,7 +366,7 @@ icingaweb2:
   image:
     repository: icinga/icingaweb2
     tag: 2.12.1
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
**NOTE**: This PR depends on #41. Make sure to merge that one first. Commits from that PR are also included here to ease testing.

This PR adds a chart for deploying
[Icinga Kubernetes](https://github.com/Icinga/icinga-kubernetes) and
[Icinga Kubernetes Web](https://github.com/Icinga/icinga-kubernetes-web).

Note that the chart is subject to change as `Icinga Kubernetes` is not
yet released, especially regarding the configuration. At the moment, a
configuration file is mounted from a `ConfigMap` that does not support
secrets, as `Icinga Kubernetes` lacks support for environment variables.
This will change in the near future.

I also chose to depend on the `Bitnami Common Library Chart` as it
provides nice common template helpers which we just copy around
at the moment.

