### PR TITLE
Raise `Icinga Web` version to `2.12.1` and `Always` pull image 

### DIFF
--- a/charts/icinga-stack/charts/icingaweb2/values.yaml
+++ b/charts/icinga-stack/charts/icingaweb2/values.yaml
@@ -3,7 +3,7 @@ enabled: true
 image:
   repository: icinga/icingaweb2
   tag: 2.12.1
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 imagePullSecrets: []
 

--- a/charts/icinga-stack/charts/icingaweb2/values.yaml
+++ b/charts/icinga-stack/charts/icingaweb2/values.yaml
@@ -2,7 +2,7 @@ enabled: true
 
 image:
   repository: icinga/icingaweb2
-  tag: 2.11.4
+  tag: 2.12.1
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -365,7 +365,7 @@ icingaweb2:
 
   image:
     repository: icinga/icingaweb2
-    tag: 2.11.4
+    tag: 2.12.1
     pullPolicy: IfNotPresent
 
   imagePullSecrets: []

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -366,7 +366,7 @@ icingaweb2:
   image:
     repository: icinga/icingaweb2
     tag: 2.12.1
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
The version raise is required to have `Icinga Kubernetes Web` and
a recent version of `Icinga Director`.

In addition, pull policy is changed to `Always`:

Although the Icinga Web image tags are coupled to release tags,
several modules are included. We rebuild the image using the same latest
release tag when modules get new release, so the image needs to be
pulled again in such cases. Updates to the base image (OS) are also
pushed using the same tags. This does not only apply to this image, so
the pull policy for all other images should also be reconsidered.