### PR TITLE
Fix product names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,5 +37,5 @@ To maintain a certain style of tests throughout the charts, please adhere to the
 
 * Tests for subcharts should be placed in the `./tests` directory of the parent chart and prefixed with the subchart's name, e.g. `icingaweb2_deployment_test.yaml`.
 * Tests should be grouped by the template they are testing.
-* Test files should be named after the template they are testing, e.g. IcingaWeb2's `deployment.yaml` should be tested in `icingaweb2_deployment_test.yaml`.
+* Test files should be named after the template they are testing, e.g. Icinga Web's `deployment.yaml` should be tested in `icingaweb2_deployment_test.yaml`.
 * **Test Suites** should be prefixed with the name of the product/chart they test, e.g. *[Icinga 2] Test Icinga 2 persistence*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,4 +38,4 @@ To maintain a certain style of tests throughout the charts, please adhere to the
 * Tests for subcharts should be placed in the `./tests` directory of the parent chart and prefixed with the subchart's name, e.g. `icingaweb2_deployment_test.yaml`.
 * Tests should be grouped by the template they are testing.
 * Test files should be named after the template they are testing, e.g. IcingaWeb2's `deployment.yaml` should be tested in `icingaweb2_deployment_test.yaml`.
-* **Test Suites** should be prefixed with the name of the chart they test, e.g. *[Icinga2] Test Icinga2 persistence*
+* **Test Suites** should be prefixed with the name of the product/chart they test, e.g. *[Icinga 2] Test Icinga 2 persistence*

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Icinga2 Kubernetes Helm Charts
+# Icinga Kubernetes Helm Charts
 
-This repository serves as a central repository to host all Icinga2 related Helm charts.
+This repository serves as a central repository to host all Icinga related Helm charts.
 
-[Icinga2](https://icinga.com) is a monitoring system which checks the availability of your network resources, notifies users of outages, and generates performance data for reporting.
+[Icinga](https://icinga.com) is a monitoring system which checks the availability of your network resources, notifies users of outages, and generates performance data for reporting.
 
 [Helm](https://helm.sh) is a tool for managing Kubernetes charts. Charts are packages of pre-configured Kubernetes resources.
 
 ### Add Helm repository
 
-First you need to add the Icinga2 Helm repository to your Helm installation. Helm repositories are similar to package repositories in Linux distributions as in they contain different available packages of 
+First you need to add the Icinga Helm repository to your Helm installation. Helm repositories are similar to package repositories in Linux distributions as in they contain different available packages of 
 Kubernetes manifests for users to consume.
 
-The Icinga2 Helm repository is hosted on GitHub Pages and can be added to your Helm installation by running the following command:
+The Icinga Helm repository is hosted on GitHub Pages and can be added to your Helm installation by running the following command:
 
 ```console
 helm repo add icinga https://icinga.github.io/helm-charts

--- a/charts/icinga-stack/README.md
+++ b/charts/icinga-stack/README.md
@@ -1,8 +1,8 @@
-# Icinga2 Kubernetes Helm Charts
+# Icinga Kubernetes Helm Charts
 
 > **WARNING**: This chart is currently in alpha state and should not be used in production. Breaking changes in future releases are well possible.
 
-[Icinga2](https://icinga.com) is a monitoring system which checks the availability of your network resources, notifies users of outages, and generates performance data for reporting.
+[Icinga](https://icinga.com) is a monitoring system which checks the availability of your network resources, notifies users of outages, and generates performance data for reporting.
 
 [Helm](https://helm.sh) is a tool for managing Kubernetes charts. Charts are packages of pre-configured Kubernetes resources.
 
@@ -19,19 +19,19 @@ This chart bootstraps a complete Icinga environment on a [Kubernetes](http://kub
 
 ### Add Helm repository
 
-First you need to add the Icinga2 Helm repository to your Helm installation. Helm repositories are similar to package repositories in Linux distributions as in they contain different available packages of 
+First you need to add the Icinga Helm repository to your Helm installation. Helm repositories are similar to package repositories in Linux distributions as in they contain different available packages of 
 Kubernetes manifests for users to consume.
 
-The Icinga2 Helm repository is hosted on GitHub Pages and can be added to your Helm installation by running the following command:
+The Icinga Helm repository is hosted on GitHub Pages and can be added to your Helm installation by running the following command:
 
 ```console
 helm repo add icinga https://icinga.github.io/helm-charts
 helm repo update
 ```
 
-### Install Icinga2
+### Install Icinga
 
-Once the repository is known to your Helm installation, you can install Icinga2 by running the following command:
+Once the repository is known to your Helm installation, you can install Icinga by running the following command:
 
 ```console
 helm install <release-name> \

--- a/charts/icinga-stack/charts/icinga2/templates/_core_config.tpl
+++ b/charts/icinga-stack/charts/icinga2/templates/_core_config.tpl
@@ -1,5 +1,5 @@
 {{- define "icinga2.config" -}}
-// Constants for Icinga2 from constants.conf
+// Constants for Icinga 2 from constants.conf
 const PluginDir = "/usr/lib/nagios/plugins"
 const ManubulonPluginDir = "/usr/lib/nagios/plugins"
 const PluginContribDir = "/usr/lib/nagios/plugins"

--- a/charts/icinga-stack/charts/icingaweb2/templates/_icingaweb-config.tpl
+++ b/charts/icinga-stack/charts/icingaweb2/templates/_icingaweb-config.tpl
@@ -36,7 +36,7 @@
       name: {{ .Values.auth.admin_password.credSecret | quote }}
       key: {{ .Values.auth.admin_password.secretKey | quote }}
 {{- else }}
-{{ fail "IcingaWeb2 auth admin password not set. Set either .Values.icingaweb2.auth.admin_password.value or .Values.icingaweb2.auth.admin_password.credSecret and .Values.icingaweb2.auth.admin_password.secretKey" }}
+{{ fail "Icinga Web auth admin password not set. Set either .Values.icingaweb2.auth.admin_password.value or .Values.icingaweb2.auth.admin_password.credSecret and .Values.icingaweb2.auth.admin_password.secretKey" }}
 {{- end}}
 - name: icingaweb.config.global.config_resource
   value: {{ .Values.auth.resource | default .Values.global.databases.icingaweb2.database | quote }}

--- a/charts/icinga-stack/docs/configuration.md
+++ b/charts/icinga-stack/docs/configuration.md
@@ -99,29 +99,29 @@ These values are used by the Icinga 2 sub-chart. For configuration of Icinga 2's
 | `icinga2.podSecurityContext.fsGroup` | Filesystem group of the Icinga 2 pods | `number` | `5665` |
 | `icinga2.podSecurityContext` | Security context of the Icinga 2 pods | `map[string]string` | `{}` |
 
-### IcingaDB values
+### Icinga DB values
 
-These values are used by the IcingaDB sub-chart.
+These values are used by the Icinga DB sub-chart.
 
 | Parameter | Description | Data Type | Default |
 | --------- | ----------- | --------- | ------- |
-| `icingadb.enabled` | Whether or not to deploy IcingaDB | `boolean` | `true` |
-| `icingadb.image.repository` | Repository of the IcingaDB image | `string` | `icinga/icingadb` |
-| `icingadb.image.tag` | Tag of the IcingaDB image | `string` | `1.1.0` |
-| `icingadb.image.pullPolicy` | Pull policy of the IcingaDB image | `string` | `IfNotPresent` |
-| `icingadb.imagePullSecrets` | Pull secrets of the IcingaDB image | `[]string` | `[]` |
-| `icingadb.nameOverride` | Name override of the IcingaDB deployment | `string` | `""` |
-| `icingadb.fullnameOverride` | Fullname override of the IcingaDB deployment | `string` | `""` |
-| `icingadb.resources` | Resources of the IcingaDB deployment | `map[string]string` | `{}` |
-| `icingadb.nodeSelector` | Node selector of the IcingaDB deployment | `map[string]string` | `{}` |
-| `icingadb.tolerations` | Tolerations of the IcingaDB deployment | `[]map[string]string` | `[]` |
-| `icingadb.affinity` | Affinity of the IcingaDB deployment | `map[string]string` | `{}` |
-| `icingadb.serviceAccount.create` | Whether or not to create a service account for the IcingaDB deployment | `boolean` | `false` |
-| `icingadb.serviceAccount.annotations` | Annotations of the IcingaDB service account | `map[string]string` | `{}` |
-| `icingadb.serviceAccount.name` | Name of the IcingaDB service account | `string` |  `""` |
-| `icingadb.podAnnotations` | Annotations of the IcingaDB pods | `map[string]string` | `{}` |
-| `icingadb.podSecurityContext` | Security context of the IcingaDB pods | `map[string]string` | `{}` |
-| `icingadb.securityContext` | Security context of the IcingaDB container | `map[string]string` | `{}` |
+| `icingadb.enabled` | Whether or not to deploy Icinga DB | `boolean` | `true` |
+| `icingadb.image.repository` | Repository of the Icinga DB image | `string` | `icinga/icingadb` |
+| `icingadb.image.tag` | Tag of the Icinga DB image | `string` | `1.1.0` |
+| `icingadb.image.pullPolicy` | Pull policy of the Icinga DB image | `string` | `IfNotPresent` |
+| `icingadb.imagePullSecrets` | Pull secrets of the Icinga DB image | `[]string` | `[]` |
+| `icingadb.nameOverride` | Name override of the Icinga DB deployment | `string` | `""` |
+| `icingadb.fullnameOverride` | Fullname override of the Icinga DB deployment | `string` | `""` |
+| `icingadb.resources` | Resources of the Icinga DB deployment | `map[string]string` | `{}` |
+| `icingadb.nodeSelector` | Node selector of the Icinga DB deployment | `map[string]string` | `{}` |
+| `icingadb.tolerations` | Tolerations of the Icinga DB deployment | `[]map[string]string` | `[]` |
+| `icingadb.affinity` | Affinity of the Icinga DB deployment | `map[string]string` | `{}` |
+| `icingadb.serviceAccount.create` | Whether or not to create a service account for the Icinga DB deployment | `boolean` | `false` |
+| `icingadb.serviceAccount.annotations` | Annotations of the Icinga DB service account | `map[string]string` | `{}` |
+| `icingadb.serviceAccount.name` | Name of the Icinga DB service account | `string` |  `""` |
+| `icingadb.podAnnotations` | Annotations of the Icinga DB pods | `map[string]string` | `{}` |
+| `icingadb.podSecurityContext` | Security context of the Icinga DB pods | `map[string]string` | `{}` |
+| `icingadb.securityContext` | Security context of the Icinga DB container | `map[string]string` | `{}` |
 
 ### Icinga Web values
 

--- a/charts/icinga-stack/docs/configuration.md
+++ b/charts/icinga-stack/docs/configuration.md
@@ -2,7 +2,7 @@
 
 The configuration for this chart is done via entries in `values.yaml` in the project's root directory. The following tables lists the configurable parameters of the chart and their default values.
 
-For configuration of Icinga2's different **features**, please see the section about [Icinga2 features](#icinga2-features).
+For configuration of Icinga 2's different **features**, please see the section about [Icinga 2 features](#icinga-2-features).
 
 For configuration of IcingaWeb2's different **modules**, please see the section about [IcingaWeb2 modules](#icingaweb2-modules).
 
@@ -33,8 +33,8 @@ These values are used by multiple (sub-)charts and therefore need to be set in t
 | --------- | ----------- | --------- | ------- |
 | `global.api.host` | Hostname of the Icinga 2 API | `string` | **not set** |
 | `global.api.port` | Port of the Icinga 2 API | `number` | `5665` |
-| `global.api.users.director.permissions` | Permissions of the Icinga2 API user for Director | `[]string` | `["*"]` |
-| `global.api.users.icingaweb.permissions` | Permissions of the Icinga2 API user for Icingaweb2 | `[]string` | `["*"]` |
+| `global.api.users.director.permissions` | Permissions of the Icinga 2 API user for Director | `[]string` | `["*"]` |
+| `global.api.users.icingaweb.permissions` | Permissions of the Icinga 2 API user for Icingaweb2 | `[]string` | `["*"]` |
 | `global.databases.<database>.database` | Name of the respective database | `string` | `<database>db`|
 | `global.databases.<database>.username.value` | Username for the respective database. Can be set from secret defined by `global.databases.<database>.credSecret` and `global.databases.<database>.username.secretKey` | `string` | **not set** |  |
 | `global.databases.<database>.password.value` | Password for the respective database. Can be set from secret defined by `global.databases.<database>.credSecret` and `global.databases.<database>.password.secretKey` | `string` | **not set** |  |
@@ -53,34 +53,34 @@ These values are used by multiple (sub-)charts and therefore need to be set in t
 | `global.redis.host` | Hostname of the Redis instance | `string` | **not set** |
 | `global.redis.port` | Port of the Redis instance | `number` | **not set** |
 
-### Icinga2 values
+### Icinga 2 values
 
-These values are used by the Icinga2 sub-chart. For configuration of Icinga2's different **features**, please see the section about [Icinga2 features](#icinga2-features).
+These values are used by the Icinga 2 sub-chart. For configuration of Icinga 2's different **features**, please see the section about [Icinga 2 features](#icinga-2-features).
 
 | Parameter | Description | Data Type | Default |
 | --------- | ----------- | --------- | ------- |
-| `icinga2.image.repository` | Repository of the Icinga2 image | `string` | `icinga/icinga2` |
-| `icinga2.image.tag` | Tag of the Icinga2 image | `string` | `2.13.7` |
-| `icinga2.image.pullPolicy` | Pull policy of the Icinga2 image | `string` | `IfNotPresent` |
-| `icinga2.imagePullSecrets` | Pull secrets of the Icinga2 image | `[]string` | `[]` |
-| `icinga2.nameOverride` | Name override of the Icinga2 deployment | `string` | `""` |
-| `icinga2.fullnameOverride` | Fullname override of the Icinga2 deployment | `string` | `""` |
-| `icinga2.service.type` | Type of the Icinga2 service | `string` | `ClusterIP` |
-| `icinga2.service.port` | Port of the Icinga2 service | `number` | `5665` |
-| `icinga2.ingress.enabled` | Whether or not to deploy an ingress for Icinga2 | `boolean` | `false` |
-| `icinga2.ingress.className` | Class name of the Icinga2 ingress | `string` | `""` |
-| `icinga2.ingress.annotations` | Annotations of the Icinga2 ingress | `map[string]string` | `{}` |
-| `icinga2.ingress.hosts[].host` | Host of the Icinga2 ingress | `string` | **not set** |
-| `icinga2.ingress.hosts[].paths[].path` | Path of the Icinga2 ingress | `string` | `/` |
-| `icinga2.ingress.hosts[].paths[].pathType` | Path type of the Icinga2 ingress | `string` | `ImplementationSpecific` |
-| `icinga2.ingress.tls[].hosts[]` | Hosts of the Icinga2 ingress | `[]string` | **not set** |
-| `icinga2.ingress.tls[].secretName` | Secret name of the Icinga2 ingress | `string` | **not set** |
-| `icinga2.config.node_name` | Name of the Icinga2 node | `string` | `icinga2-master` |
-| `icinga2.config.zone_name` | Name of the Icinga2 zone | `string` | `master` |
+| `icinga2.image.repository` | Repository of the Icinga 2 image | `string` | `icinga/icinga2` |
+| `icinga2.image.tag` | Tag of the Icinga 2 image | `string` | `2.13.7` |
+| `icinga2.image.pullPolicy` | Pull policy of the Icinga 2 image | `string` | `IfNotPresent` |
+| `icinga2.imagePullSecrets` | Pull secrets of the Icinga 2 image | `[]string` | `[]` |
+| `icinga2.nameOverride` | Name override of the Icinga 2 deployment | `string` | `""` |
+| `icinga2.fullnameOverride` | Fullname override of the Icinga 2 deployment | `string` | `""` |
+| `icinga2.service.type` | Type of the Icinga 2 service | `string` | `ClusterIP` |
+| `icinga2.service.port` | Port of the Icinga 2 service | `number` | `5665` |
+| `icinga2.ingress.enabled` | Whether or not to deploy an ingress for Icinga 2 | `boolean` | `false` |
+| `icinga2.ingress.className` | Class name of the Icinga 2 ingress | `string` | `""` |
+| `icinga2.ingress.annotations` | Annotations of the Icinga 2 ingress | `map[string]string` | `{}` |
+| `icinga2.ingress.hosts[].host` | Host of the Icinga 2 ingress | `string` | **not set** |
+| `icinga2.ingress.hosts[].paths[].path` | Path of the Icinga 2 ingress | `string` | `/` |
+| `icinga2.ingress.hosts[].paths[].pathType` | Path type of the Icinga 2 ingress | `string` | `ImplementationSpecific` |
+| `icinga2.ingress.tls[].hosts[]` | Hosts of the Icinga 2 ingress | `[]string` | **not set** |
+| `icinga2.ingress.tls[].secretName` | Secret name of the Icinga 2 ingress | `string` | **not set** |
+| `icinga2.config.node_name` | Name of the Icinga 2 node | `string` | `icinga2-master` |
+| `icinga2.config.zone_name` | Name of the Icinga 2 zone | `string` | `master` |
 | `icinga2.config.disable_confd` | Disables the `include_recursive "conf.d"` directive in icinga2.conf | `boolean` | `true` |
 | `icinga2.config.ticket_salt.value` | Salt used to generate API tickets for satellites and agents. Can be set from secret specified in `icinga2.config.ticket_salt.credSecret` and `icinga2.config.ticket_salt.secretKey` | `string` | **not set** |
 | `icinga2.features.<feature>.enabled` | Whether or not the respective feature should be enabled | `boolean` | **varies** |
-| `icinga2.persistence.enabled` | Whether or not the Icinga2 deployment should use a persistent volume | `boolean` | `false` |
+| `icinga2.persistence.enabled` | Whether or not the Icinga 2 deployment should use a persistent volume | `boolean` | `false` |
 | `icinga2.persistence.size` | Size of the persistent volume | `string` | `5Gi` |
 | `icinga2.persistence.accessMode` | Access mode of the persistent volume | `string` | `ReadWriteOnce` |
 | `icinga2.persistence.storageClass` | Storage class of the persistent volume | `string` | **not set** |
@@ -88,16 +88,16 @@ These values are used by the Icinga2 sub-chart. For configuration of Icinga2's d
 | `icinga2.persistence.subPath` | Subpath of the persistent volume | `string` | **not set** |
 | `icinga2.persistence.matchLabels` | Labels to match for the persistent volume | `map[string]string` | `{}` |
 | `icinga2.persistence.matchExpressions` | Expressions to match for the persistent volume | `[]map[string]string` | `[]`|
-| `icinga2.resources` | Resources of the Icinga2 deployment | `map[string]string` | `{}` |
-| `icinga2.nodeSelector` | Node selector of the Icinga2 deployment | `map[string]string` | `{}` |
-| `icinga2.tolerations` | Tolerations of the Icinga2 deployment | `[]map[string]string` | `[]` |
-| `icinga2.affinity` | Affinity of the Icinga2 deployment | `map[string]string` | `{}` |
-| `icinga2.serviceAccount.create` | Whether or not to create a service account for the Icinga2 deployment | `boolean` | `false` |
-| `icinga2.serviceAccount.annotations` | Annotations of the Icinga2 service account | `map[string]string` | `{}` |
-| `icinga2.serviceAccount.name` | Name of the Icinga2 service account | `string` |  `""` |
-| `icinga2.podAnnotations` | Annotations of the Icinga2 pods | `map[string]string` | `{}` |
-| `icinga2.podSecurityContext.fsGroup` | Filesystem group of the Icinga2 pods | `number` | `5665` |
-| `icinga2.podSecurityContext` | Security context of the Icinga2 pods | `map[string]string` | `{}` |
+| `icinga2.resources` | Resources of the Icinga 2 deployment | `map[string]string` | `{}` |
+| `icinga2.nodeSelector` | Node selector of the Icinga 2 deployment | `map[string]string` | `{}` |
+| `icinga2.tolerations` | Tolerations of the Icinga 2 deployment | `[]map[string]string` | `[]` |
+| `icinga2.affinity` | Affinity of the Icinga 2 deployment | `map[string]string` | `{}` |
+| `icinga2.serviceAccount.create` | Whether or not to create a service account for the Icinga 2 deployment | `boolean` | `false` |
+| `icinga2.serviceAccount.annotations` | Annotations of the Icinga 2 service account | `map[string]string` | `{}` |
+| `icinga2.serviceAccount.name` | Name of the Icinga 2 service account | `string` |  `""` |
+| `icinga2.podAnnotations` | Annotations of the Icinga 2 pods | `map[string]string` | `{}` |
+| `icinga2.podSecurityContext.fsGroup` | Filesystem group of the Icinga 2 pods | `number` | `5665` |
+| `icinga2.podSecurityContext` | Security context of the Icinga 2 pods | `map[string]string` | `{}` |
 
 ### IcingaDB values
 
@@ -161,9 +161,9 @@ These values are used by the IcingaWeb2 sub-chart. For configuration of Icingawe
 | `icingaweb2.podSecurityContext` | Security context of the IcingaWeb2 pods | `map[string]string` | `{}` |
 | `icingaweb2.securityContext` | Security context of the IcingaWeb2 container | `map[string]string` | `{}` |
 
-## Icinga2 Features
+## Icinga 2 Features
 
-The feature set of Icinga2 supported by this Helmchart is **opinionated**. We deliberately chose to omit some features, either because they are listed as **deprecated** in the official documentation or just have no real use-case when run on Kubernetes. Below is a list of currently supported features, with links to the official documentation, if available:
+The feature set of Icinga 2 supported by this Helmchart is **opinionated**. We deliberately chose to omit some features, either because they are listed as **deprecated** in the official documentation or just have no real use-case when run on Kubernetes. Below is a list of currently supported features, with links to the official documentation, if available:
 
 - `api` [Documentation](https://icinga.com/docs/icinga-2/latest/doc/12-icinga2-api/#icinga2-api)
 - `checker`

--- a/charts/icinga-stack/docs/configuration.md
+++ b/charts/icinga-stack/docs/configuration.md
@@ -4,7 +4,7 @@ The configuration for this chart is done via entries in `values.yaml` in the pro
 
 For configuration of Icinga 2's different **features**, please see the section about [Icinga 2 features](#icinga-2-features).
 
-For configuration of IcingaWeb2's different **modules**, please see the section about [IcingaWeb2 modules](#icingaweb2-modules).
+For configuration of Icinga Web's different **modules**, please see the section about [Icinga Web modules](#icinga-web-modules).
 
 ## Values configuration
 
@@ -21,9 +21,9 @@ The values can be set in the chart's `values.yaml` file or via the `--set` flag 
 | Parameter | Description | Remarks | Kubernetes secret parameters |
 | --------- | ----------- | ------- | ---------------------------- |
 | `icinga2.config.ticket_salt.value` | Salt used to generate API tickets for satellites and agents | - | `icinga2.config.ticket_salt.credSecret`, `icinga2.config.ticket_salt.secretKey` |
-| `icingaweb2.auth.admin_password.value` | Password for the Icinga Web 2 admin user | Only needs to be set if Icingaweb2 is `enabled` | `icingaweb2.auth.admin_password.credSecret`, `icingaweb2.auth.admin_password.secretKey` |
+| `icingaweb2.auth.admin_password.value` | Password for the Icinga Web admin user | Only needs to be set if Icinga Web is `enabled` | `icingaweb2.auth.admin_password.credSecret`, `icingaweb2.auth.admin_password.secretKey` |
 | `global.api.users.director.password.value` | Password for the Icinga Director API user | Only needs to be set if Director is `enabled` | `global.api.users.credSecret`, `global.api.users.director.password.secretKey` |
-| `global.api.users.icingaweb.password.value` | Password for the Icingaweb2 API user| Only needs to be set if Icingaweb2 is `enabled` | `global.api.users.credSecret`, `global.api.users.icingaweb.password.secretKey` |
+| `global.api.users.icingaweb.password.value` | Password for the Icinga Web API user| Only needs to be set if Icinga Web is `enabled` | `global.api.users.credSecret`, `global.api.users.icingaweb.password.secretKey` |
 
 ### Global values
 
@@ -34,7 +34,7 @@ These values are used by multiple (sub-)charts and therefore need to be set in t
 | `global.api.host` | Hostname of the Icinga 2 API | `string` | **not set** |
 | `global.api.port` | Port of the Icinga 2 API | `number` | `5665` |
 | `global.api.users.director.permissions` | Permissions of the Icinga 2 API user for Director | `[]string` | `["*"]` |
-| `global.api.users.icingaweb.permissions` | Permissions of the Icinga 2 API user for Icingaweb2 | `[]string` | `["*"]` |
+| `global.api.users.icingaweb.permissions` | Permissions of the Icinga 2 API user for Icinga Web | `[]string` | `["*"]` |
 | `global.databases.<database>.database` | Name of the respective database | `string` | `<database>db`|
 | `global.databases.<database>.username.value` | Username for the respective database. Can be set from secret defined by `global.databases.<database>.credSecret` and `global.databases.<database>.username.secretKey` | `string` | **not set** |  |
 | `global.databases.<database>.password.value` | Password for the respective database. Can be set from secret defined by `global.databases.<database>.credSecret` and `global.databases.<database>.password.secretKey` | `string` | **not set** |  |
@@ -123,43 +123,43 @@ These values are used by the IcingaDB sub-chart.
 | `icingadb.podSecurityContext` | Security context of the IcingaDB pods | `map[string]string` | `{}` |
 | `icingadb.securityContext` | Security context of the IcingaDB container | `map[string]string` | `{}` |
 
-### IcingaWeb2 values
+### Icinga Web values
 
-These values are used by the IcingaWeb2 sub-chart. For configuration of Icingaweb2's different **modules**, please see the section about [Icingaweb2 modules](#icingaweb2-modules).
+These values are used by the Icinga Web sub-chart. For configuration of Icinga Web's different **modules**, please see the section about [Icinga Web modules](#icinga-web-modules).
 
 | Parameter | Description | Data Type | Default |
 | --------- | ----------- | --------- | ------- |
-| `icingaweb2.enabled` | Whether or not to deploy IcingaWeb2 | `boolean` | `true` |
-| `icingaweb2.image.repository` | Repository of the IcingaWeb2 image | `string` | `icinga/icingaweb2` |
-| `icingaweb2.image.tag` | Tag of the IcingaWeb2 image | `string` | `2.11.4` |
-| `icingaweb2.image.pullPolicy` | Pull policy of the IcingaWeb2 image | `string` | `IfNotPresent` |
-| `icingaweb2.imagePullSecrets` | Pull secrets of the IcingaWeb2 image | `[]string` | `[]` |
-| `icingaweb2.nameOverride` | Name override of the IcingaWeb2 deployment | `string` | `""` |
-| `icingaweb2.fullnameOverride` | Fullname override of the IcingaWeb2 deployment | `string` | `""` |
-| `icingaweb2.service.type` | Type of the IcingaWeb2 service | `string` | `ClusterIP` |
-| `icingaweb2.service.port` | Port of the IcingaWeb2 service | `number` | `8080` |
-| `icingaweb2.ingress.enabled` | Whether or not to create an ingress for the IcingaWeb2 service | `boolean` | `false` |
-| `icingaweb2.ingress.className` | Class name of the IcingaWeb2 ingress | `string` | `""` |
-| `icingaweb2.ingress.annotations` | Annotations of the IcingaWeb2 ingress | `map[string]string` | `{}` |
-| `icingaweb2.ingress.hosts[].host` | Host of the IcingaWeb2 ingress | `string` | **not set** |
-| `icingaweb2.ingress.hosts[].paths[].path` | Path of the IcingaWeb2 ingress | `string` | `/` |
-| `icingaweb2.ingress.hosts[].paths[].pathType` | Path type of the IcingaWeb2 ingress | `string` | `ImplementationSpecific` |
-| `icingaweb2.ingress.tls[].hosts` | Hosts of the IcingaWeb2 ingress | `[]string` | **not set** |
-| `icingaweb2.ingress.tls[].secretName` | Secret name of the IcingaWeb2 ingress | `string` | **not set** |
-| `icingaweb2.auth.type` | Type of the IcingaWeb2 authentication | `string` | `db` |
-| `icingaweb2.auth.admin_user` | Admin user of the IcingaWeb2 authentication | `string` | `icingaweb` |
-| `icingaweb2.auth.admin_password.value` | Admin password of the IcingaWeb2 authentication. Can be set from secret specified in `icingaweb2.auth.admin_password.credSecret` and `icingaweb2.auth.admin_password.secretKey` | `string` | **not set** |
-| `icingaweb2.modules.<module>.enabled` | Whether or not to enable the IcingaWeb2 module | `boolean` | **varies** |
-| `icingaweb2.resources` | Resources of the IcingaWeb2 deployment | `map[string]string` | `{}` |
-| `icingaweb2.nodeSelector` | Node selector of the IcingaWeb2 deployment | `map[string]string` | `{}` |
-| `icingaweb2.tolerations` | Tolerations of the IcingaWeb2 deployment | `[]map[string]string` | `[]` |
-| `icingaweb2.affinity` | Affinity of the IcingaWeb2 deployment | `map[string]string` | `{}` |
-| `icingaweb2.serviceAccount.create` | Whether or not to create a service account for the IcingaWeb2 deployment | `boolean` | `false` |
-| `icingaweb2.serviceAccount.annotations` | Annotations of the IcingaWeb2 service account | `map[string]string` | `{}` |
-| `icingaweb2.serviceAccount.name` | Name of the IcingaWeb2 service account | `string` |  `""` |
-| `icingaweb2.podAnnotations` | Annotations of the IcingaWeb2 pods | `map[string]string` | `{}` |
-| `icingaweb2.podSecurityContext` | Security context of the IcingaWeb2 pods | `map[string]string` | `{}` |
-| `icingaweb2.securityContext` | Security context of the IcingaWeb2 container | `map[string]string` | `{}` |
+| `icingaweb2.enabled` | Whether or not to deploy Icinga Web | `boolean` | `true` |
+| `icingaweb2.image.repository` | Repository of the Icinga Web image | `string` | `icinga/icingaweb2` |
+| `icingaweb2.image.tag` | Tag of the Icinga Web image | `string` | `2.11.4` |
+| `icingaweb2.image.pullPolicy` | Pull policy of the Icinga Web image | `string` | `IfNotPresent` |
+| `icingaweb2.imagePullSecrets` | Pull secrets of the Icinga Web image | `[]string` | `[]` |
+| `icingaweb2.nameOverride` | Name override of the Icinga Web deployment | `string` | `""` |
+| `icingaweb2.fullnameOverride` | Fullname override of the Icinga Web deployment | `string` | `""` |
+| `icingaweb2.service.type` | Type of the Icinga Web service | `string` | `ClusterIP` |
+| `icingaweb2.service.port` | Port of the Icinga Web service | `number` | `8080` |
+| `icingaweb2.ingress.enabled` | Whether or not to create an ingress for the Icinga Web service | `boolean` | `false` |
+| `icingaweb2.ingress.className` | Class name of the Icinga Web ingress | `string` | `""` |
+| `icingaweb2.ingress.annotations` | Annotations of the Icinga Web ingress | `map[string]string` | `{}` |
+| `icingaweb2.ingress.hosts[].host` | Host of the Icinga Web ingress | `string` | **not set** |
+| `icingaweb2.ingress.hosts[].paths[].path` | Path of the Icinga Web ingress | `string` | `/` |
+| `icingaweb2.ingress.hosts[].paths[].pathType` | Path type of the Icinga Web ingress | `string` | `ImplementationSpecific` |
+| `icingaweb2.ingress.tls[].hosts` | Hosts of the Icinga Web ingress | `[]string` | **not set** |
+| `icingaweb2.ingress.tls[].secretName` | Secret name of the Icinga Web ingress | `string` | **not set** |
+| `icingaweb2.auth.type` | Type of the Icinga Web authentication | `string` | `db` |
+| `icingaweb2.auth.admin_user` | Admin user of the Icinga Web authentication | `string` | `icingaweb` |
+| `icingaweb2.auth.admin_password.value` | Admin password of the Icinga Web authentication. Can be set from secret specified in `icingaweb2.auth.admin_password.credSecret` and `icingaweb2.auth.admin_password.secretKey` | `string` | **not set** |
+| `icingaweb2.modules.<module>.enabled` | Whether or not to enable the Icinga Web module | `boolean` | **varies** |
+| `icingaweb2.resources` | Resources of the Icinga Web deployment | `map[string]string` | `{}` |
+| `icingaweb2.nodeSelector` | Node selector of the Icinga Web deployment | `map[string]string` | `{}` |
+| `icingaweb2.tolerations` | Tolerations of the Icinga Web deployment | `[]map[string]string` | `[]` |
+| `icingaweb2.affinity` | Affinity of the Icinga Web deployment | `map[string]string` | `{}` |
+| `icingaweb2.serviceAccount.create` | Whether or not to create a service account for the Icinga Web deployment | `boolean` | `false` |
+| `icingaweb2.serviceAccount.annotations` | Annotations of the Icinga Web service account | `map[string]string` | `{}` |
+| `icingaweb2.serviceAccount.name` | Name of the Icinga Web service account | `string` |  `""` |
+| `icingaweb2.podAnnotations` | Annotations of the Icinga Web pods | `map[string]string` | `{}` |
+| `icingaweb2.podSecurityContext` | Security context of the Icinga Web pods | `map[string]string` | `{}` |
+| `icingaweb2.securityContext` | Security context of the Icinga Web container | `map[string]string` | `{}` |
 
 ## Icinga 2 Features
 
@@ -182,9 +182,9 @@ The feature set of Icinga 2 supported by this Helmchart is **opinionated**. We d
 
 **Configuration** of these features is done via the `values.yaml` file. A **commented** version of all available values is provided with this repository. Please refer to the official documentation linked above for more information on how to configure these features.
 
-## IcingaWeb2 Modules
+## Icinga Web Modules
 
-The module set of IcingaWeb2 supported by this Helmchart is **opinionated**. We deliberately chose to omit some modules, either because they are **deprecated** or just have no real use-case when run on Kubernetes. Below is a list of currently supported modules, with links to the official documentation, if available:
+The module set of Icinga Web supported by this Helmchart is **opinionated**. We deliberately chose to omit some modules, either because they are **deprecated** or just have no real use-case when run on Kubernetes. Below is a list of currently supported modules, with links to the official documentation, if available:
 
 - `audit` [Documentation](https://github.com/icinga/icingaweb2-module-audit)
 - `businessprocess` [Documentation](https://icinga.com/docs/icinga-business-process-modelling/latest/doc/01-About/)

--- a/charts/icinga-stack/tests/global_database_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/global_database_statefulset_test.yaml
@@ -135,8 +135,8 @@ tests:
       - failedTemplate:
           errorMessage: "director password not set. Set either .Values.global.databases.director.password.value or .Values.global.databases.director.credSecret and .Values.global.databases.director.password.secretKey"
 
-  # IcingaDB DB
-  - it: deploys an IcingaDB database StatefulSet using values
+  # Icinga DB DB
+  - it: deploys an Icinga DB database StatefulSet using values
     documentIndex: 2
     values:
       - required_values.yaml
@@ -160,7 +160,7 @@ tests:
             name: MARIADB_PASSWORD
             value: insecureicingadbpassword
 
-  - it: deploys an IcingaDB database StatefulSet using secrets
+  - it: deploys an Icinga DB database StatefulSet using secrets
     documentIndex: 2
     values:
       - required_values_secrets.yaml

--- a/charts/icinga-stack/tests/global_database_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/global_database_statefulset_test.yaml
@@ -191,7 +191,7 @@ tests:
                 key: password
 
   # IcingaWeb DB
-  - it: deploys an Icingaweb2 database StatefulSet using values
+  - it: deploys an Icinga Web database StatefulSet using values
     documentIndex: 4
     values:
       - required_values.yaml
@@ -215,7 +215,7 @@ tests:
             name: MARIADB_PASSWORD
             value: insecureicingaweb2password
 
-  - it: deploys an Icingaweb2 database StatefulSet using secrets
+  - it: deploys an Icinga Web database StatefulSet using secrets
     documentIndex: 4
     values:
       - required_values_secrets.yaml

--- a/charts/icinga-stack/tests/icinga2_configmaps_test.yaml
+++ b/charts/icinga-stack/tests/icinga2_configmaps_test.yaml
@@ -1,8 +1,8 @@
-suite: "[Icinga2] Configmaps"
+suite: "[Icinga 2] Configmaps"
 templates:
   - ../charts/icinga2/templates/configmaps.yaml
 tests:
-  - it: Icinga2 configmap ticket_salt and api-users test
+  - it: Icinga 2 configmap ticket_salt and api-users test
     values:
       - required_values.yaml
     release:
@@ -24,7 +24,7 @@ tests:
           pattern: password = getenv\("ICINGA_ICINGAWEB_API_PASSWORD"\)
         documentIndex: 0
 
-  - it: Icinga2 configmap elasticsearch test
+  - it: Icinga 2 configmap elasticsearch test
     values:
       - required_values.yaml
     set:
@@ -52,7 +52,7 @@ tests:
           pattern: password = getenv\("ICINGA_ELASTICSEARCH_PASSWORD"\)
         documentIndex: 1
 
-  - it: Icinga2 configmap elasticsearch tls test
+  - it: Icinga 2 configmap elasticsearch tls test
     values:
       - required_values.yaml
     set:
@@ -97,7 +97,7 @@ tests:
           pattern: key_path = "/etc/icinga2-pki/elastic/cert.key"
         documentIndex: 1
 
-  - it: Icinga2 configmap elasticsearch tls failure
+  - it: Icinga 2 configmap elasticsearch tls failure
     values:
       - required_values.yaml
     set:
@@ -118,7 +118,7 @@ tests:
       - failedTemplate:
           errorMessage: "Elasticsearch cert secrets not set. Set .Values.features.elasticsearch.tlsSecret, .Values.features.elasticsearch.caSecretKey, .Values.features.elasticsearch.certSecretKey and .Values.features.elasticsearch.keySecretKey"
 
-  - it: Icinga2 configmap gelf tls test
+  - it: Icinga 2 configmap gelf tls test
     values:
       - required_values.yaml
     set:
@@ -150,7 +150,7 @@ tests:
           pattern: key_path = "/etc/icinga2-pki/gelf/cert.key"
         documentIndex: 1
 
-  - it: Icinga2 configmap gelf tls failure
+  - it: Icinga 2 configmap gelf tls failure
     values:
       - required_values.yaml
     set:
@@ -167,7 +167,7 @@ tests:
       - failedTemplate:
           errorMessage: "GELF cert secrets not set. Set .Values.features.gelf.tlsSecret, .Values.features.gelf.caSecretKey, .Values.features.gelf.certSecretKey and .Values.features.gelf.keySecretKey"
 
-  - it: Icinga2 configmap icingadb test without password
+  - it: Icinga 2 configmap icingadb test without password
     values:
       - required_values.yaml
     set:
@@ -187,7 +187,7 @@ tests:
         documentIndex: 1
         not: true
 
-  - it: Icinga2 configmap icingadb test with password
+  - it: Icinga 2 configmap icingadb test with password
     values:
       - required_values.yaml
     set:
@@ -209,7 +209,7 @@ tests:
           pattern: password = getenv\("ICINGA_ICINGADB_PASSWORD"\)
         documentIndex: 1
 
-  - it: Icinga2 configmap icingadb tls test
+  - it: Icinga 2 configmap icingadb tls test
     values:
       - required_values.yaml
     set:
@@ -246,7 +246,7 @@ tests:
           pattern: crl_path = "/etc/icinga2-pki/icingadb/crl.pem"
         documentIndex: 1
 
-  - it: Icinga2 configmap icingadb tls failure
+  - it: Icinga 2 configmap icingadb tls failure
     values:
       - required_values.yaml
     set:
@@ -265,7 +265,7 @@ tests:
       - failedTemplate:
           errorMessage: "icingadb cert secrets not set. Set .Values.features.icingadb.tlsSecret, .Values.features.icingadb.caSecretKey, .Values.features.icingadb.certSecretKey, .Values.features.icingadb.keySecretKey and .Values.features.icingadb.crlSecretKey"
 
-  - it: Icinga2 configmap influxdb2 ssl test
+  - it: Icinga 2 configmap influxdb2 ssl test
     values:
       - required_values.yaml
     set:
@@ -297,7 +297,7 @@ tests:
           pattern: ssl_key = "/etc/icinga2-pki/influxdb2/cert.key"
         documentIndex: 1
 
-  - it: Icinga2 configmap influxdb2 tls failure
+  - it: Icinga 2 configmap influxdb2 tls failure
     values:
       - required_values.yaml
     set:
@@ -316,7 +316,7 @@ tests:
       - failedTemplate:
           errorMessage: "influxdb2 cert secrets not set. Set .Values.features.influxdb2.tlsSecret, .Values.features.influxdb2.caSecretKey, .Values.features.influxdb2.certSecretKey and .Values.features.influxdb2.keySecretKey"
 
-  - it: Icinga2 configmap influxdb ssl test
+  - it: Icinga 2 configmap influxdb ssl test
     values:
       - required_values.yaml
     set:
@@ -348,7 +348,7 @@ tests:
           pattern: ssl_key = "/etc/icinga2-pki/influxdb/cert.key"
         documentIndex: 1
 
-  - it: Icinga2 configmap influxdb tls failure
+  - it: Icinga 2 configmap influxdb tls failure
     values:
       - required_values.yaml
     set:
@@ -367,7 +367,7 @@ tests:
       - failedTemplate:
           errorMessage: "influxdb cert secrets not set. Set .Values.features.influxdb.tlsSecret, .Values.features.influxdb.caSecretKey, .Values.features.influxdb.certSecretKey and .Values.features.influxdb.keySecretKey"
 
-  - it: Icinga2 configmap influxdb2 test
+  - it: Icinga 2 configmap influxdb2 test
     values:
       - required_values.yaml
     set:
@@ -389,7 +389,7 @@ tests:
           pattern: auth_token = getenv\("ICINGA_INFLUXDB2_AUTH_TOKEN"\)
         documentIndex: 1
 
-  - it: Icinga2 configmap influxdb credentials from secret
+  - it: Icinga 2 configmap influxdb credentials from secret
     values:
       - required_values.yaml
     set:
@@ -417,7 +417,7 @@ tests:
           pattern: password = getenv\("ICINGA_INFLUXDB_PASSWORD"\)
         documentIndex: 1
 
-  - it: Icinga2 configmap influxdb credentials from value
+  - it: Icinga 2 configmap influxdb credentials from value
     values:
       - required_values.yaml
     set:
@@ -444,7 +444,7 @@ tests:
           pattern: password = getenv\("ICINGA_INFLUXDB_PASSWORD"\)
         documentIndex: 1
         
-  - it: Icinga2 configmap influxdb basic auth credentials from secret
+  - it: Icinga 2 configmap influxdb basic auth credentials from secret
     values:
       - required_values.yaml
     set:

--- a/charts/icinga-stack/tests/icinga2_ingress_test.yaml
+++ b/charts/icinga-stack/tests/icinga2_ingress_test.yaml
@@ -1,4 +1,4 @@
-suite: "[Icinga2] Ingress creation"
+suite: "[Icinga 2] Ingress creation"
 templates:
   - ../charts/icinga2/templates/ingress.yaml
 tests:

--- a/charts/icinga-stack/tests/icinga2_statefulset_test.yaml
+++ b/charts/icinga-stack/tests/icinga2_statefulset_test.yaml
@@ -1,8 +1,8 @@
-suite: "[Icinga2] StatefulSet"
+suite: "[Icinga 2] StatefulSet"
 templates:
   - ../charts/icinga2/templates/statefulset.yaml
 tests:
-  - it: deploys an Icinga2 StatefulSet without persistence and with ticket_salt provided as value
+  - it: deploys an Icinga 2 StatefulSet without persistence and with ticket_salt provided as value
     values:
       - required_values.yaml
     release:
@@ -53,7 +53,7 @@ tests:
             name: ICINGA_ICINGAWEB_API_PASSWORD
             value: "icingaweb-insecurepassword"
 
-  - it: deploys an Icinga2 StatefulSet without persistence and with ticket_salt provided as secret
+  - it: deploys an Icinga 2 StatefulSet without persistence and with ticket_salt provided as secret
     values:
       - required_values_secrets.yaml
     release:
@@ -122,7 +122,7 @@ tests:
                 name: "api-users"
                 key: "icingaweb-password"
 
-  - it: failed deployment of Icinga2 StatefulSet due to partial secret definition
+  - it: failed deployment of Icinga 2 StatefulSet due to partial secret definition
     values:
       - required_values_secrets.yaml
     set:
@@ -141,7 +141,7 @@ tests:
       - failedTemplate:
           errorMessage: "director api user password not set. Set either .Values.global.api.users.director.password.value or .Values.global.api.users.credSecret and .Values.global.api.users.director.password.secretKey"
   
-  - it: deploys an Icinga2 StatefulSet with persistence
+  - it: deploys an Icinga 2 StatefulSet with persistence
     values:
       - required_values.yaml
     set:
@@ -176,7 +176,7 @@ tests:
             emptyDir: {}
           any: true
 
-  - it: failed deployment of an Icinga2 StatefulSet due to missing ticket_salt
+  - it: failed deployment of an Icinga 2 StatefulSet due to missing ticket_salt
     values:
       - required_values.yaml
     set:
@@ -189,7 +189,7 @@ tests:
       - failedTemplate:
           errorMessage: "Icinga TicketSalt not set. Either set .Values.config.ticket_salt.value or .Values.config.ticket_salt.credSecret and .Values.config.ticket_salt.secretKey"
 
-  - it: deploys an Icinga2 StatefulSet with elasticsearch values
+  - it: deploys an Icinga 2 StatefulSet with elasticsearch values
     values:
       - required_values.yaml
     set:
@@ -232,7 +232,7 @@ tests:
             name: ICINGA_ELASTICSEARCH_PASSWORD
             value: "elastic-password"
 
-  - it: deploys an Icinga2 StatefulSet with elasticsearch secrets
+  - it: deploys an Icinga 2 StatefulSet with elasticsearch secrets
     values:
       - required_values.yaml
     set:
@@ -282,7 +282,7 @@ tests:
                 name: "icinga-elasticsearch"
                 key: "elastic-password"
 
-  - it: deploys an Icinga2 StatefulSet with elasticsearch secrets with tls
+  - it: deploys an Icinga 2 StatefulSet with elasticsearch secrets with tls
     values:
       - required_values.yaml
     set:
@@ -356,7 +356,7 @@ tests:
               - key: "elastic-key-key"
                 path: "cert.key"
 
-  - it: deploys an Icinga2 StatefulSet with gelf secrets with tls
+  - it: deploys an Icinga 2 StatefulSet with gelf secrets with tls
     values:
       - required_values.yaml
     set:
@@ -409,7 +409,7 @@ tests:
               - key: "gelf-key-key"
                 path: "cert.key"
 
-  - it: deploys an Icinga2 StatefulSet with icingadb password value
+  - it: deploys an Icinga 2 StatefulSet with icingadb password value
     values:
       - required_values.yaml
     set:
@@ -443,7 +443,7 @@ tests:
             name: ICINGA_ICINGADB_PASSWORD
             value: "icingadb-password"
 
-  - it: deploys an Icinga2 StatefulSet with icingadb secrets with tls
+  - it: deploys an Icinga 2 StatefulSet with icingadb secrets with tls
     values:
       - required_values.yaml
     set:
@@ -510,7 +510,7 @@ tests:
               - key: "icingadb-crl-key"
                 path: "crl.pem"
 
-  - it: deploys an Icinga2 StatefulSet with influxdb2 values
+  - it: deploys an Icinga 2 StatefulSet with influxdb2 values
     values:
       - required_values.yaml
     set:
@@ -546,7 +546,7 @@ tests:
             name: ICINGA_INFLUXDB2_AUTH_TOKEN
             value: "influxdb2_auth_token"
 
-  - it: deploys an Icinga2 StatefulSet with influxdb2 secrets
+  - it: deploys an Icinga 2 StatefulSet with influxdb2 secrets
     values:
       - required_values.yaml
     set:
@@ -586,7 +586,7 @@ tests:
                 name: "icinga-influxdb2"
                 key: "authToken"
 
-  - it: deploys an Icinga2 StatefulSet with influxdb2 secrets with ssl
+  - it: deploys an Icinga 2 StatefulSet with influxdb2 secrets with ssl
     values:
       - required_values.yaml
     set:
@@ -651,7 +651,7 @@ tests:
               - key: "influxdb2-key-key"
                 path: "cert.key"
 
-  - it: failed deployment of an Icinga2 StatefulSet with influxdb2 due to missing auth_token
+  - it: failed deployment of an Icinga 2 StatefulSet with influxdb2 due to missing auth_token
     values:
       - required_values.yaml
     set:
@@ -668,7 +668,7 @@ tests:
       - failedTemplate:
           errorMessage: "Icinga InfluxDB2 auth_token not set. Either set .Values.features.influxdb2.auth_token.value or .Values.features.influxdb2.credSecret and .Values.features.influxdb2.auth_token.secretKey"
 
-  - it: deploys an Icinga2 StatefulSet with influxdb values
+  - it: deploys an Icinga 2 StatefulSet with influxdb values
     values:
       - required_values.yaml
     set:
@@ -726,7 +726,7 @@ tests:
             name: ICINGA_INFLUXDB_BASIC_AUTH_PASSWORD
             value: "influxdb-basic-auth-password"
             
-  - it: deploys an Icinga2 StatefulSet with influxdb secrets
+  - it: deploys an Icinga 2 StatefulSet with influxdb secrets
     values:
       - required_values.yaml
     set:
@@ -797,7 +797,7 @@ tests:
                 name: "icinga-influxdb"
                 key: "basic-auth-password"
             
-  - it: deploys an Icinga2 StatefulSet with influxdb secrets with ssl
+  - it: deploys an Icinga 2 StatefulSet with influxdb secrets with ssl
     values:
       - required_values.yaml
     set:
@@ -892,7 +892,7 @@ tests:
               - key: "influxdb-key-key"
                 path: "cert.key"
 
-  - it: deploys an Icinga2 StatefulSet with extra environment variables
+  - it: deploys an Icinga 2 StatefulSet with extra environment variables
     values:
       - required_values.yaml
     set:

--- a/charts/icinga-stack/tests/icingadb_deployment_test.yaml
+++ b/charts/icinga-stack/tests/icingadb_deployment_test.yaml
@@ -1,8 +1,8 @@
-suite: "[IcingaDB] Deployment"
+suite: "[Icinga DB] Deployment"
 templates:
   - ../charts/icingadb/templates/deployment.yaml
 tests:
-  - it: deploys an IcingaDB deployment
+  - it: deploys an Icinga DB deployment
     values:
       - required_values.yaml
     release:
@@ -15,7 +15,7 @@ tests:
           path: metadata.name
           value: my-icinga-icingadb
 
-  - it: deploys an IcingaDB deployment using values
+  - it: deploys an Icinga DB deployment using values
     values:
       - required_values.yaml
     release:
@@ -38,7 +38,7 @@ tests:
             name: ICINGADB_DATABASE_PASSWORD
             value: insecureicingadbpassword
 
-  - it: deploys an IcingaDB deployment using secrets
+  - it: deploys an Icinga DB deployment using secrets
     values:
       - required_values_secrets.yaml
     release:
@@ -67,7 +67,7 @@ tests:
                 name: database-icingadb
                 key: password
 
-  - it: deploys an IcingaDB deployment with extra environment variables
+  - it: deploys an Icinga DB deployment with extra environment variables
     values:
       - required_values.yaml
     set:

--- a/charts/icinga-stack/tests/icingaweb2_deployment_test.yaml
+++ b/charts/icinga-stack/tests/icingaweb2_deployment_test.yaml
@@ -1,8 +1,8 @@
-suite: "[Icingaweb2] Deployment"
+suite: "[Icinga Web] Deployment"
 templates:
   - ../charts/icingaweb2/templates/deployment.yaml
 tests:
-  - it: deploys an Icingaweb2 deployment with minimal configuration
+  - it: deploys an Icinga Web deployment with minimal configuration
     values:
       - required_values.yaml
     release:
@@ -26,7 +26,7 @@ tests:
             name: icingaweb.passwords.icingaweb2.icingaweb
             value: insecurepassword
 
-  - it: deploys an Icingaweb2 deployment with additional modules
+  - it: deploys an Icinga Web deployment with additional modules
     values:
       - required_values.yaml
     set:
@@ -53,7 +53,7 @@ tests:
             value: director,icingadb,incubator,x509,
           any: true
   
-  - it: deploys an Icingaweb2 deployment with minimal configuration using secrets
+  - it: deploys an Icinga Web deployment with minimal configuration using secrets
     values:
       - required_values_secrets.yaml
     release:
@@ -80,7 +80,7 @@ tests:
                 name: icingaweb2-secret
                 key: admin_password
 
-  - it: deploys an Icingaweb2 deployment with graphite
+  - it: deploys an Icinga Web deployment with graphite
     values:
       - required_values.yaml
     set:
@@ -107,7 +107,7 @@ tests:
             value: director,graphite,icingadb,incubator,
           any: true
 
-  - it: deploys an Icingaweb2 deployment with graphite, user/password from value
+  - it: deploys an Icinga Web deployment with graphite, user/password from value
     values:
       - required_values.yaml
     set:
@@ -143,7 +143,7 @@ tests:
             name: icingaweb.modules.graphite.config.graphite.password
             value: graphite-password
 
-  - it: deploys an Icingaweb2 deployment with graphite, user/password from secret
+  - it: deploys an Icinga Web deployment with graphite, user/password from secret
     values:
       - required_values.yaml
     set:
@@ -186,7 +186,7 @@ tests:
                 name: graphite-secret
                 key: graphite-password
 
-  - it: failed deployment of Icingaweb2 due to partial secret definition
+  - it: failed deployment of Icinga Web due to partial secret definition
     values:
       - required_values_secrets.yaml
     set:

--- a/charts/icinga-stack/tests/icingaweb2_ingress_test.yaml
+++ b/charts/icinga-stack/tests/icingaweb2_ingress_test.yaml
@@ -1,4 +1,4 @@
-suite: "[Icingaweb2] Ingress creation"
+suite: "[Icinga Web] Ingress creation"
 templates:
   - ../charts/icingaweb2/templates/ingress.yaml
 tests:

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -512,7 +512,7 @@ icinga-kubernetes:
 
 global:
   api:
-    # host:  # only needed if Icinga2 runs out of cluster
+    # host:  # only needed if Icinga 2 runs out of cluster
     port: 5665
     users:
       credSecret: # Existing secret for director and icingaweb password


### PR DESCRIPTION
This PR fixes incorrect spelling of our product names, i.e.
* `Icinga 2` instead of `Icinga2`,
* `Icinga Web` instead of `IcingaWeb2` / `Icingaweb2`, and
* `Icinga DB` instead of `IcingaDB`.

Please note that the transition from `Icinga Web 2` to `Icinga Web` is an ongoing process and you will still find `Icinga Web 2` here and, but new docs should use `Icinga Web`.

Additionally, I have corrected the use of `Icinga2`, referring to the entire Icinga ecosystem, to `Icinga`.