### PR TITLE
`icinga-stack`: Use `icingaadmin` as `Icinga Web` `admin_user`

### DIFF
--- a/charts/icinga-stack/charts/icingaweb2/values.yaml
+++ b/charts/icinga-stack/charts/icingaweb2/values.yaml
@@ -33,7 +33,7 @@ ingress:
 auth:
   type: db
   #resource: # Add the name of the db resource used by Icinga Web 2 here
-  admin_user: icingaweb
+  admin_user: icingaadmin
   admin_password:
     value: # Add a password here
     credSecret: # Or use existing secret

--- a/charts/icinga-stack/docs/configuration.md
+++ b/charts/icinga-stack/docs/configuration.md
@@ -147,7 +147,7 @@ These values are used by the IcingaWeb2 sub-chart. For configuration of Icingawe
 | `icingaweb2.ingress.tls[].hosts` | Hosts of the IcingaWeb2 ingress | `[]string` | **not set** |
 | `icingaweb2.ingress.tls[].secretName` | Secret name of the IcingaWeb2 ingress | `string` | **not set** |
 | `icingaweb2.auth.type` | Type of the IcingaWeb2 authentication | `string` | `db` |
-| `icingaweb2.auth.admin_user` | Admin user of the IcingaWeb2 authentication | `string` | `icingaweb` |
+| `icingaweb2.auth.admin_user` | Admin user of the IcingaWeb2 authentication | `string` | `icingaadmin` |
 | `icingaweb2.auth.admin_password.value` | Admin password of the IcingaWeb2 authentication. Can be set from secret specified in `icingaweb2.auth.admin_password.credSecret` and `icingaweb2.auth.admin_password.secretKey` | `string` | **not set** |
 | `icingaweb2.modules.<module>.enabled` | Whether or not to enable the IcingaWeb2 module | `boolean` | **varies** |
 | `icingaweb2.resources` | Resources of the IcingaWeb2 deployment | `map[string]string` | `{}` |

--- a/charts/icinga-stack/tests/icingaweb2_deployment_test.yaml
+++ b/charts/icinga-stack/tests/icingaweb2_deployment_test.yaml
@@ -23,7 +23,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: icingaweb.passwords.icingaweb2.icingaweb
+            name: icingaweb.passwords.icingaweb2.icingaadmin
             value: insecurepassword
 
   - it: deploys an Icingaweb2 deployment with additional modules
@@ -74,7 +74,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: icingaweb.passwords.icingaweb2.icingaweb
+            name: icingaweb.passwords.icingaweb2.icingaadmin
             valueFrom:
               secretKeyRef:
                 name: icingaweb2-secret

--- a/charts/icinga-stack/values.yaml
+++ b/charts/icinga-stack/values.yaml
@@ -395,7 +395,7 @@ icingaweb2:
   auth:
     type: db
     #resource: # Add the name of the db resource used by Icinga Web 2 here
-    admin_user: icingaweb
+    admin_user: icingaadmin
     admin_password:
       value: # Add a password here
       credSecret:


### PR DESCRIPTION
We have been using `icingaadmin` in our docs for a long time now.