### PR TITLE
added the possibility of using annotations for icinga2 chart and icingaweb2 chart services

### DIFF
--- a/charts/icinga-stack/charts/icinga2/templates/service.yaml
+++ b/charts/icinga-stack/charts/icinga2/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "icinga2.fullname" . }}
   labels:
     {{- include "icinga2.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/icinga-stack/charts/icinga2/values.yaml
+++ b/charts/icinga-stack/charts/icinga2/values.yaml
@@ -10,6 +10,7 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 5665
+  annotations: {}
 
 ingress:
   enabled: false

--- a/charts/icinga-stack/charts/icingaweb2/templates/service.yaml
+++ b/charts/icinga-stack/charts/icingaweb2/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "icingaweb2.fullname" . }}
   labels:
     {{- include "icingaweb2.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/icinga-stack/charts/icingaweb2/values.yaml
+++ b/charts/icinga-stack/charts/icingaweb2/values.yaml
@@ -13,6 +13,7 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 8080
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
I personally use annotations in Services, but noticed this wasn't possible in the icinga2 and icingaweb2 chart. So I added the possibility. 