### PR TITLE
Fix kubernetes database field value import

### DIFF
--- a/charts/icinga-stack/charts/icinga-kubernetes/templates/_config.tpl
+++ b/charts/icinga-stack/charts/icinga-kubernetes/templates/_config.tpl
@@ -17,7 +17,7 @@ database:
     port: {{ .Values.global.databases.kubernetes.port | default 3306 }}
 
     # Database name.
-    database: {{ .Values.global.databases.kubernetes.database.value }}
+    database: {{ .Values.global.databases.kubernetes.database }}
 
     # Database user.
     user: {{ .Values.global.databases.kubernetes.username.value }}


### PR DESCRIPTION
Fixes the following bug:

```
Error: INSTALLATION FAILED: template:
icinga-stack/charts/icingaweb2/templates/deployment.yaml:41:16: executing
"icinga-stack/charts/icingaweb2/templates/deployment.yaml" at <include
"icingaweb2.config" .>: error calling include: template:
icinga-stack/charts/icingaweb2/templates/_icingaweb-config.tpl:140:19:
executing "icingaweb2.config" at
<.Values.global.databases.kubernetes.database.value>: can't evaluate field
value in type interface {}
```