### PR TITLE
activate entrypoint from icinga2 container

### DIFF
--- a/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
+++ b/charts/icinga-stack/charts/icinga2/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
             - name: api
               containerPort: {{ .Values.service.port }}
               protocol: TCP
-          command:
+          args:
             - icinga2
             - daemon
           volumeMounts:


### PR DESCRIPTION
The `entrypoint` of the icinga2 image is creating the `~icinga/.msmtprc` via the environment variable `MSMTPRC`. The `initContainer` uses the `entrypoint` but for the container itself it is overridden.

Related to #26 